### PR TITLE
Make plug-in loading webpack-friendly

### DIFF
--- a/examples/example-server/src/app.ts
+++ b/examples/example-server/src/app.ts
@@ -51,11 +51,10 @@ import { hideBin } from 'yargs/helpers';
 
 async function loadModules(): Promise<ContainerModule[]> {
     const modules = [
-        '@eclipse-emfcloud/coffee-custom-commands-example/lib/example-commands-module',
-        '@eclipse-emfcloud/coffee-custom-validators-example/lib/example-validators-module'
+        require('@eclipse-emfcloud/coffee-custom-commands-example/lib/example-commands-module'),
+        require('@eclipse-emfcloud/coffee-custom-validators-example/lib/example-validators-module')
     ];
 
-    // eslint-disable @typescript-eslint/no-var-requires
-    const required = modules.map(path => require(path)).map(module => module.default);
-    return Promise.resolve(required);
+    const result = modules.map(module => module.default);
+    return Promise.resolve(result);
 }

--- a/packages/modelserver-node/src/di.ts
+++ b/packages/modelserver-node/src/di.ts
@@ -33,11 +33,10 @@ export async function createContainer(modelServerPort: number, loggingLevel: Log
 }
 
 async function loadModules(): Promise<ContainerModule[]> {
-    const modules = ['./logging-module', './server-module', './routes/routing-module'];
+    const modules = [require('./logging-module'), require('./server-module'), require('./routes/routing-module')];
 
-    // eslint-disable @typescript-eslint/no-var-requires
-    const required = modules.map(path => require(path)).map(module => module.default);
-    return Promise.resolve(required);
+    const result = modules.map(module => module.default);
+    return Promise.resolve(result);
 }
 
 function modelServerModule(modelServerPort: number): ContainerModule {


### PR DESCRIPTION
- only require literal module names

Fixes #3.

Contributed on behalf of STMicroelectronics.
