### PR TITLE
Fix early continuation after patch trigger

### DIFF
--- a/packages/modelserver-node/src/trigger-provider-registry.ts
+++ b/packages/modelserver-node/src/trigger-provider-registry.ts
@@ -136,8 +136,8 @@ function multiTriggerProvider(triggerProviders: TriggerProvider[]): TriggerProvi
                     if (!result) {
                         break;
                     }
-                } else {
-                    executor.applyPatch(provided);
+                } else if (provided.length) {
+                    result = (await executor.applyPatch(provided)).success;
                 }
             }
 


### PR DESCRIPTION
- add the missing `await`
- add test coverage to check for early continuation
- avoid applying empty patches from triggers
- improve robustness of `DefaultTransactionContext::performTriggers`

Fixes #7.

Contributed on behalf of STMicroelectronics.
