### PR TITLE
[Releng] Update version dependencies

### DIFF
--- a/examples/custom-command-example/package.json
+++ b/examples/custom-command-example/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.1.0",
+    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.2.0",
     "inversify": "^5.1.1"
   },
   "devDependencies": {

--- a/examples/custom-validator-example/package.json
+++ b/examples/custom-validator-example/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.1.0",
+    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.2.0",
     "inversify": "^5.1.1"
   },
   "devDependencies": {

--- a/examples/example-server/package.json
+++ b/examples/example-server/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-node": "~0.1.0",
+    "@eclipse-emfcloud/modelserver-node": "~0.2.0",
     "inversify": "^5.1.1",
     "yargs": "^17.3.1"
   },

--- a/examples/trigger-example/package.json
+++ b/examples/trigger-example/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.1.0",
+    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.2.0",
     "inversify": "^5.1.1"
   },
   "devDependencies": {

--- a/packages/modelserver-node/package.json
+++ b/packages/modelserver-node/package.json
@@ -25,7 +25,7 @@
     "lib"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.1.0",
+    "@eclipse-emfcloud/modelserver-plugin-ext": "~0.2.0",
     "axios": "^0.24.0",
     "express": "^4.17.1",
     "express-asyncify": "^1.0.1",


### PR DESCRIPTION
- update internal version dependencies to match package versions

This prevents multiple prompts to select the version of `@eclipse-emfcloud/modelserver-plugin-ext` package to install when building the monorepo, which shouldn't be necessary as it is provided by the monorepo.

Contributed on behalf of STMicroelectronics.
