### PR TITLE
Fix #21: Text messages not relayed as text but as binary

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,15 @@ module.exports = {
     ignorePatterns: ['**/{node_modules,lib}'],
     parserOptions: {
         tsconfigRootDir: __dirname,
-        project: 'tsconfig.json'
-    }
+        project: 'tsconfig.eslint.json'
+    },
+    overrides: [
+        {
+            files: ['*.spec.ts'],
+            rules: {
+                'no-unused-expressions': 0,
+                'no-invalid-this': 0
+            }
+        }
+    ]
 };

--- a/packages/modelserver-node/src/server.ts
+++ b/packages/modelserver-node/src/server.ts
@@ -186,10 +186,6 @@ export class ModelServer {
             const baseURL = WSUpgradeRequest.toWebsocketURL(upstreamServer.defaults.baseURL).replace(/\/+$/, '');
             const url = `${baseURL}${wsURL}`;
 
-            // Relay text data as text
-            const rawDataHelper = (sock: WebSocket) => (data: WebSocket.RawData, isBinary: boolean) =>
-                isBinary ? sock.send(data) : sock.send(data.toString());
-
             this.logger.debug(`Forwarding websocket to Upstream Model Server.`);
 
             let upstream: WebSocket;
@@ -210,3 +206,7 @@ export class ModelServer {
         };
     }
 }
+
+// Relay text data as text
+const rawDataHelper = (sock: WebSocket) => (data: WebSocket.RawData, isBinary: boolean) =>
+    isBinary ? sock.send(data) : sock.send(data.toString());

--- a/packages/modelserver-node/src/server.ts
+++ b/packages/modelserver-node/src/server.ts
@@ -186,9 +186,14 @@ export class ModelServer {
             const baseURL = WSUpgradeRequest.toWebsocketURL(upstreamServer.defaults.baseURL).replace(/\/+$/, '');
             const url = `${baseURL}${wsURL}`;
 
+            // Relay text data as text
+            const rawDataHelper = (sock: WebSocket) => (data: WebSocket.RawData, isBinary: boolean) =>
+                isBinary ? sock.send(data) : sock.send(data.toString());
+
             this.logger.debug(`Forwarding websocket to Upstream Model Server.`);
 
             let upstream: WebSocket;
+
             try {
                 upstream = new WebSocket(url);
 
@@ -196,8 +201,8 @@ export class ModelServer {
                 upstream.on('error', handleError('upstream', this.logger, downstream));
                 downstream.on('close', handleClose('downstream', this.logger, upstream));
                 upstream.on('close', handleClose('upstream', this.logger, downstream));
-                downstream.on('message', msg => upstream.send(msg));
-                upstream.on('message', msg => downstream.send(msg));
+                downstream.on('message', rawDataHelper(upstream));
+                upstream.on('message', rawDataHelper(downstream));
             } catch (error) {
                 // The only exception caught here should be in creating the upstream socket
                 handleError('upstream', this.logger, downstream)(error);

--- a/packages/modelserver-node/src/trigger-provider-registry.spec.ts
+++ b/packages/modelserver-node/src/trigger-provider-registry.spec.ts
@@ -8,13 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-import { Logger, Transaction, TriggerProvider } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { ModelServerCommand } from '@eclipse-emfcloud/modelserver-client';
-import * as sinon from 'sinon';
-import { expect } from 'chai';
-import { Container } from 'inversify';
-import { Operation } from 'fast-json-patch';
+import { Logger, Transaction, TriggerProvider } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { assert } from '@sinonjs/referee';
+import { expect } from 'chai';
+import { Operation } from 'fast-json-patch';
+import { Container } from 'inversify';
+import * as sinon from 'sinon';
 
 import { TriggerProviderRegistry } from './trigger-provider-registry';
 
@@ -23,7 +23,9 @@ describe('TriggerProviderRegistry', () => {
 
     beforeEach(() => {
         const logger: Logger = {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
             debug: () => {},
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
             info: () => {}
         } as any;
 
@@ -105,14 +107,14 @@ function registerProviders(registry: TriggerProviderRegistry, ...providers: Trig
 }
 
 class AsyncCounter {
-    count: number = 0;
+    count = 0;
 
     async tick<T>(action?: T | (() => T)): Promise<T | undefined> {
         return new Promise(resolve => {
             setTimeout(() => {
                 this.count = this.count + 1;
                 if (typeof action === 'function') {
-                    resolve((action as Function)());
+                    resolve((action as () => T)());
                 }
                 return resolve(action as T);
             }, 5);

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/node_modules"]
+}


### PR DESCRIPTION
Update the generic WebSocket message relay to
forward non-binary messages as strings.

Contributed on behalf of STMicroelectronics.
