### PR TITLE
24: Add modelUri to CommandProvider

### DIFF
--- a/examples/custom-command-example/src/example-command.ts
+++ b/examples/custom-command-example/src/example-command.ts
@@ -52,7 +52,7 @@ class IncrementDurationCommandProvider implements CommandProvider {
         return true; // The command type filter is all I need
     }
 
-    getCommands(customCommand: ModelServerCommand): Transaction {
+    getCommands(_modelUri: string, customCommand: ModelServerCommand): Transaction {
         const [modelURI, elementID] = customCommand.owner.$ref.split('#');
 
         return async executor => {

--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -431,7 +431,7 @@ class DefaultTransactionContext implements TransactionContext {
     }
 
     // Doc inherited from `Executor` interface
-    async execute(command: ModelServerCommand): Promise<ModelUpdateResult> {
+    async execute(modelUri: string, command: ModelServerCommand): Promise<ModelUpdateResult> {
         if (!this.socket) {
             return Promise.reject('Socket is closed.');
         }
@@ -443,7 +443,7 @@ class DefaultTransactionContext implements TransactionContext {
         } else {
             this.logger.debug(`Getting commands provided recursively for ${command.type}`);
 
-            const provided = await this.commandProviderRegistry.getCommands(command);
+            const provided = await this.commandProviderRegistry.getCommands(modelUri, command);
             if (typeof provided === 'function') {
                 // It's a transaction function. We already have a transaction context (this one)
                 this.pushNestedContext();

--- a/packages/modelserver-node/src/command-provider-registry.ts
+++ b/packages/modelserver-node/src/command-provider-registry.ts
@@ -81,16 +81,17 @@ export class CommandProviderRegistry {
     /**
      * Obtain the commands to forward to the _Upstream Model Server_ to implement the given custom command.
      *
+     * @param modelUri the URI of the model being edited.
      * @param customCommand get the commands provided for a given custom command
      * @returns the provided command, command transaction, or the original `customCommand` standing in for itself
      *    if no provider can handle the custom command
      */
-    async getCommands(customCommand: ModelServerCommand): Promise<ModelServerCommand | Operation[] | Transaction> {
+    async getCommands(modelUri: string, customCommand: ModelServerCommand): Promise<ModelServerCommand | Operation[] | Transaction> {
         let result: ModelServerCommand | Operation[] | Transaction | undefined;
         const provider = this.getProvider(customCommand);
         if (provider) {
             this.logger.debug(`Invoking provider for custom ${customCommand.type} command`);
-            result = await provider.getCommands(customCommand);
+            result = await provider.getCommands(modelUri, customCommand);
 
             if (!result) {
                 this.logger.warn(`No commands provided. Custom ${customCommand.type} command will be unhandled.`);

--- a/packages/modelserver-node/src/routes/models.ts
+++ b/packages/modelserver-node/src/routes/models.ts
@@ -146,7 +146,7 @@ export class ModelsRoutes implements RouteProvider {
     protected async handleCommand(modelURI: string, command: ModelServerCommand, res: Response<any, Record<string, any>>): Promise<void> {
         this.logger.debug(`Getting commands provided for ${command.type}`);
 
-        const provided = await this.commandProviderRegistry.getCommands(command);
+        const provided = await this.commandProviderRegistry.getCommands(modelURI, command);
         this.forwardEdit(modelURI, provided, res);
     }
 
@@ -209,7 +209,7 @@ export class ModelsRoutes implements RouteProvider {
                 // It's a command or JSON Patch. Just execute/apply it in the usual way
                 if (ModelServerCommand.is(providedEdit)) {
                     // Command case
-                    await executor.execute(providedEdit);
+                    await executor.execute(modelURI, providedEdit);
                 } else {
                     // JSON Patch case
                     await executor.applyPatch(providedEdit);

--- a/packages/modelserver-node/src/trigger-provider-registry.spec.ts
+++ b/packages/modelserver-node/src/trigger-provider-registry.spec.ts
@@ -87,7 +87,7 @@ describe('TriggerProviderRegistry', () => {
             const transaction = trigger as Transaction;
             const counter = new AsyncCounter();
             const executor = sinon.spy({
-                execute: async (command: ModelServerCommand) => counter.tick({ success: true }),
+                execute: async (modelUri: string, command: ModelServerCommand) => counter.tick({ success: true }),
                 applyPatch: async (patch: Operation | Operation[]) => counter.tick({ success: true })
             });
 

--- a/packages/modelserver-plugin-ext/src/command-provider.ts
+++ b/packages/modelserver-plugin-ext/src/command-provider.ts
@@ -34,9 +34,10 @@ export interface CommandProvider {
      * Obtain a translation of the given custom command to primitive commands (one or a composite of many)
      * that the _Upstream Model Server_ understands natively.
      *
+     * @param modelUri the URI of the model being edited.
      * @param customCommand the custom command to translate to _Upstream Model Server_ primitives
      * @returns either a command to substitute for the custom command (perhaps a compound command) or a
      *     transaction that should be run in the context of a transactional compound command {@link Executor}
      */
-    getCommands(customCommand: ModelServerCommand): MaybePromise<ModelServerCommand | Transaction>;
+    getCommands(modelUri: string, customCommand: ModelServerCommand): MaybePromise<ModelServerCommand | Transaction>;
 }

--- a/packages/modelserver-plugin-ext/src/executor.ts
+++ b/packages/modelserver-plugin-ext/src/executor.ts
@@ -23,10 +23,11 @@ export interface Executor {
     /**
      * Execute a command on the model.
      *
+     * @param modelUri the URI of the model being edited.
      * @param command a command to be executed on the model
      * @return the result of the command's execution
      */
-    execute(command: ModelServerCommand): Promise<ModelUpdateResult>;
+    execute(modelUri: string, command: ModelServerCommand): Promise<ModelUpdateResult>;
 
     /**
      * Apply a JSON patch to the model.


### PR DESCRIPTION
- Add modelUri parameter to CommandProvider.getCommands()

Note: I haven't updated the example (`example-command.ts`), as it can still access the modelUri from the owner.$ref, and adding an unused parameter seemed pointless. Each command provider can decide whether they want to use the new modelUri parameter, or somehow derive the modelUri from the Command.

Contributed on behalf of STMicroelectronics.