### PR TITLE
Additional subscription query parameters are dropped

### DIFF
--- a/packages/modelserver-node/src/routes/subscription.ts
+++ b/packages/modelserver-node/src/routes/subscription.ts
@@ -73,11 +73,21 @@ export class SubscriptionRoutes implements RouteProvider {
 }
 
 function parseQuery(query: ParsedQs): SubscriptionQuery {
-    return {
+    const result = {
         modeluri: parseQueryParam(query, 'modeluri'),
         livevalidation: parseQueryParam(query, 'livevalidation', false),
         timeout: parseQueryParam(query, 'timeout', 'number')
     };
+
+    // Pass the rest through
+    for (const key of Object.keys(query)) {
+        const param = parseQueryParam(query, key);
+        if (param && !(key in result)) {
+            result[key] = param;
+        }
+    }
+
+    return result;
 }
 
 function parseQueryParam(query: ParsedQs, name: string, type?: 'string', defaultValue?: string): string | undefined;


### PR DESCRIPTION
Pass through unrecognized query parameters to the upstream subscription, with the exception still of the `livevalidation` parameter.

Resolves #26.

Contributed on behalf of STMicroelectronics.
