### PR TITLE
Incorrect mapping and merging of ModelUpdateResult

### DIFF
--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -20,7 +20,6 @@ import {
     ModelServerMessage,
     ModelServerNotification,
     ModelUpdateResult,
-    Operations,
     ServerConfiguration,
     SubscriptionListener,
     SubscriptionOptions,
@@ -476,12 +475,16 @@ class DefaultTransactionContext implements TransactionContext {
         }
 
         const { aggregatedUpdateResult: current } = this.peekNestedContext();
-        const result = WebSocketMessageAcceptor.promise<ModelUpdateResult>(this.socket, message => {
-            const matched = message.type === 'success' && Operations.isPatch(message.data.patch);
-            if (matched && current) {
-                this.mergeModelUpdateResult(current, MessageDataMapper.patchModel(message));
+        const result = WebSocketMessageAcceptor.promise<any, ModelUpdateResult>(
+            this.socket,
+            message => true, // Need to accept and merge failed updates as well as successful
+            MessageDataMapper.patchModel
+        ).then(modelUpdateResult => {
+            // If we are currently tracking a merged update result, incorporate this new result
+            if (current) {
+                this.mergeModelUpdateResult(current, modelUpdateResult);
             }
-            return matched;
+            return modelUpdateResult;
         });
 
         this.socket.send(JSON.stringify(this.message('execute', body)));

--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -479,7 +479,7 @@ class DefaultTransactionContext implements TransactionContext {
         const result = WebSocketMessageAcceptor.promise<ModelUpdateResult>(this.socket, message => {
             const matched = message.type === 'success' && Operations.isPatch(message.data.patch);
             if (matched && current) {
-                this.mergeModelUpdateResult(current, message.data);
+                this.mergeModelUpdateResult(current, MessageDataMapper.patchModel(message));
             }
             return matched;
         });
@@ -535,7 +535,12 @@ class DefaultTransactionContext implements TransactionContext {
      */
     private mergeModelUpdateResult(dst: ModelUpdateResult, src?: ModelUpdateResult): void {
         if (src?.patch && src.patch.length) {
+            dst.success = dst.success && src.success;
             dst.patch = (dst.patch ?? []).concat(src.patch);
+
+            if (dst.success && src.patchModel) {
+                dst.patchModel = src.patchModel;
+            }
         }
     }
 


### PR DESCRIPTION
Fix the execution reply message in a transaction to correctly map the `message` to a `ModelUpdateResult`, then merge that.
Also merge the `success` and `patchModel` properties, in addition to the `patch` property.

Resolves #28.

Contributed on behalf of STMicroelectronics.
