### PR TITLE
#31: Triggers not invoked for first edit in a transaction

### DIFF
--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -34,7 +34,7 @@ import * as WebSocket from 'ws';
 
 import { CommandProviderRegistry } from '../command-provider-registry';
 import { TriggerProviderRegistry } from '../trigger-provider-registry';
-import { defer, Deferred } from './promise-utils';
+import { CompletablePromise } from './promise-utils';
 import { WebSocketMessageAcceptor } from './web-socket-utils';
 
 export const UpstreamConnectionConfig = Symbol('UpstreamConnectionConfig');
@@ -360,7 +360,7 @@ class DefaultTransactionContext implements TransactionContext {
 
     private nestedContexts: NestedEditContext[] = [];
 
-    private readonly uuid: Deferred<string>;
+    private readonly uuid: CompletablePromise<string>;
 
     constructor(
         protected readonly transactionURI: string,
@@ -375,7 +375,7 @@ class DefaultTransactionContext implements TransactionContext {
         this.close = this.close.bind(this);
         this.rollback = this.rollback.bind(this);
 
-        this.uuid = defer();
+        this.uuid = CompletablePromise.newPromise();
     }
 
     /**
@@ -428,8 +428,8 @@ class DefaultTransactionContext implements TransactionContext {
      *
      * @returns the UUID, when it is available
      */
-    getUUID(): Promise<string> {
-        return this.uuid.promise();
+    getUUID(): PromiseLike<string> {
+        return this.uuid;
     }
 
     // Doc inherited from `Executor` interface

--- a/packages/modelserver-node/src/client/promise-utils.spec.ts
+++ b/packages/modelserver-node/src/client/promise-utils.spec.ts
@@ -10,32 +10,56 @@
  *******************************************************************************/
 import { expect } from 'chai';
 
-import { defer } from './promise-utils';
+import { CompletablePromise } from './promise-utils';
 
 describe('Deferred', () => {
     it('#resolve', async () => {
-        const deferred = defer<string>();
+        const promise = CompletablePromise.newPromise<string>();
 
         setTimeout(() => {
-            deferred.resolve('Hello, world!');
+            promise.resolve('Hello, world!');
         }, 0);
 
-        const message = await deferred.promise();
+        const message = await promise;
         expect(message).to.equal('Hello, world!');
     });
 
     it('#reject', async () => {
-        const deferred = defer<string>();
+        const promise = CompletablePromise.newPromise<string>();
 
         setTimeout(() => {
-            deferred.reject(new Error('Bad data'));
+            promise.reject(new Error('Bad data'));
         }, 0);
 
         try {
-            await deferred.promise();
+            await promise;
         } catch (e) {
             expect(e).to.be.instanceOf(Error);
             expect(e.message).to.be.equal('Bad data');
         }
+    });
+
+    it('#then', async () => {
+        const promise = CompletablePromise.newPromise<{ x: string }>();
+        const then = promise.then(value => value.x);
+
+        setTimeout(() => {
+            promise.resolve({ x: 'Hello, world!' });
+        }, 0);
+
+        const message = await then;
+        expect(message).to.equal('Hello, world!');
+    });
+
+    it('#catch', async () => {
+        const promise = CompletablePromise.newPromise<string>();
+        const catch_ = promise.catch(e => e.toString());
+
+        setTimeout(() => {
+            promise.reject(new Error('Bad data'));
+        }, 0);
+
+        const message = await catch_;
+        expect(message).to.be.equal('Error: Bad data');
     });
 });

--- a/packages/modelserver-node/src/client/promise-utils.spec.ts
+++ b/packages/modelserver-node/src/client/promise-utils.spec.ts
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+import { expect } from 'chai';
+
+import { defer } from './promise-utils';
+
+describe('Deferred', () => {
+    it('#resolve', async () => {
+        const deferred = defer<string>();
+
+        setTimeout(() => {
+            deferred.resolve('Hello, world!');
+        }, 0);
+
+        const message = await deferred.promise();
+        expect(message).to.equal('Hello, world!');
+    });
+
+    it('#reject', async () => {
+        const deferred = defer<string>();
+
+        setTimeout(() => {
+            deferred.reject(new Error('Bad data'));
+        }, 0);
+
+        try {
+            await deferred.promise();
+        } catch (e) {
+            expect(e).to.be.instanceOf(Error);
+            expect(e.message).to.be.equal('Bad data');
+        }
+    });
+});

--- a/packages/modelserver-node/src/client/promise-utils.ts
+++ b/packages/modelserver-node/src/client/promise-utils.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+
+/**
+ * A simple protocol for a deferred value: an externally settlable promise.
+ */
+export interface Deferred<T> {
+    /** Obtain the deferred value. */
+    promise(): Promise<T>;
+    /** Resolve the deferred value. */
+    resolve(value: T | PromiseLike<T>): void;
+    /** Reject the deferred value. */
+    reject(reason?: any): void;
+}
+
+/**
+ * Create a new deferred value.
+ *
+ * @returns a new deferred value
+ */
+export function defer<T>(): Deferred<T> {
+    return new DeferredImpl<T>();
+}
+
+class DeferredImpl<T> implements Deferred<T> {
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+
+    private readonly promise_: Promise<T>;
+
+    constructor() {
+        this.promise_ = new Promise((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+
+    promise(): Promise<T> {
+        return this.promise_;
+    }
+}


### PR DESCRIPTION
Process the reply message from transaction open explicitly and block sending execute messages until it has been processed.

Fixes #31.

Contributed on behalf of STMicroelectronics.
