### PR TITLE
Fix #34: Provide initial validation state in subscriptions

### DIFF
--- a/packages/modelserver-node/src/services/subscription-manager.ts
+++ b/packages/modelserver-node/src/services/subscription-manager.ts
@@ -9,8 +9,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 
-import { Diagnostic, MessageType } from '@eclipse-emfcloud/modelserver-client';
+import { Diagnostic, MessageType, ModelServerMessage } from '@eclipse-emfcloud/modelserver-client';
 import { Logger } from '@eclipse-emfcloud/modelserver-plugin-ext';
+import { EventEmitter } from 'events';
 import { inject, injectable, named } from 'inversify';
 import { stringify as unparseQuery } from 'qs';
 import * as WebSocket from 'ws';
@@ -21,7 +22,7 @@ import { handleClose, handleError, JSONSocket } from '../client/web-socket-utils
 /**
  * Query parameters for the `GET` request on the `subscribe` endpoint.
  */
-interface SubscriptionQuery {
+export interface SubscriptionQuery {
     /** The model URI to subscribe to. */
     modeluri: string;
     /** Whether the subscriber wishes to receive live validation diagnostics. */
@@ -35,6 +36,8 @@ interface SubscriptionQuery {
 
 type Client = JSONSocket & { options?: SubscriptionQuery };
 
+export type EventType = 'subscribed' | 'unsubscribed';
+
 @injectable()
 export class SubscriptionManager {
     @inject(Logger)
@@ -47,7 +50,9 @@ export class SubscriptionManager {
     /** Map of downstream (client) socket to upstream (Upstream Model Server) socket. */
     protected readonly subscriptions: Map<Client, JSONSocket> = new Map();
 
-    addSubscription(client: WebSocket, endpoint: string, params: SubscriptionQuery): void {
+    protected readonly eventEmitter = new EventEmitter();
+
+    addSubscription(client: WebSocket, endpoint: string, params: SubscriptionQuery): JSONSocket {
         // Drop the livevalidation option from the upstream subscription because we handle
         // live validation broadcasts in the Model Server node.js layer
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -69,7 +74,10 @@ export class SubscriptionManager {
             downstream.onMessage(msg => upstream.send(msg));
 
             // Clean-up on close
-            const cleanupHandler: () => void = () => this.subscriptions.delete(downstream);
+            const cleanupHandler: () => void = () => {
+                this.subscriptions.delete(downstream);
+                this.fireEvent('unsubscribed', downstream, params);
+            };
             downstream.onClose(cleanupHandler);
             upstream.onClose(cleanupHandler);
 
@@ -81,16 +89,74 @@ export class SubscriptionManager {
             // The only exception caught here should be in creating the upstream socket
             handleError('upstream', this.logger, downstream)(error);
         }
+
+        this.fireEvent('subscribed', downstream, params);
+
+        return downstream;
+    }
+
+    protected fireEvent(eventType: EventType, client: JSONSocket, params: SubscriptionQuery): void {
+        this.eventEmitter.emit(eventType, client, params);
+    }
+
+    addSubscribedListener(listener: (client: JSONSocket, params: SubscriptionQuery) => void): this {
+        this.eventEmitter.on('subscribed', listener);
+        return this;
+    }
+
+    removeSubscribedListener(listener: (client: JSONSocket, params: SubscriptionQuery) => void): this {
+        this.eventEmitter.off('subscribed', listener);
+        return this;
+    }
+
+    addUnsubscribedListener(listener: (client: JSONSocket, params: SubscriptionQuery) => void): this {
+        this.eventEmitter.on('unsubscribed', listener);
+        return this;
+    }
+
+    removeUnsubscribedListener(listener: (client: JSONSocket, params: SubscriptionQuery) => void): this {
+        this.eventEmitter.off('unsubscribed', listener);
+        return this;
+    }
+
+    /**
+     * Retrieve subscribers on a model URI. If provided, the `filter` may be either
+     *
+     * - a `string` indicating a property of the subscription options that must have a truthy value, or
+     * - a `function` that tests whether the subscription options match some arbitrary predicate
+     *
+     * @param modelURI the model URI for which to get subscribers
+     * @param filter an optional subscriber filter, by options property or a generic predicate
+     * @returns the matching subscriber sockets
+     */
+    protected getSubscribers(modelURI: string, filter?: keyof SubscriptionQuery | ((options: SubscriptionQuery) => boolean)): JSONSocket[] {
+        return Array.from(this.subscriptions.keys())
+            .filter(client => client.options.modeluri === modelURI)
+            .filter(subscriberFilter(filter));
+    }
+
+    /**
+     * Query whether any subscribers are registered on a model URI. If provided, the `filter` may be either
+     *
+     * - a `string` indicating a property of the subscription options that must have a truthy value, or
+     * - a `function` that tests whether the subscription options match some arbitrary predicate
+     *
+     * @param modelURI the model URI for which to get subscribers
+     * @param filter an optional subscriber filter, by options property or a generic predicate
+     * @returns whether any matching subscriptions exist
+     */
+    protected hasSubscribers(modelURI: string, filter?: keyof SubscriptionQuery | ((options: SubscriptionQuery) => boolean)): boolean {
+        return Array.from(this.subscriptions.keys())
+            .filter(client => client.options.modeluri === modelURI)
+            .some(subscriberFilter(filter));
     }
 
     hasValidationSubscribers(modelURI: string): boolean {
-        return Array.from(this.subscriptions.keys()).some(client => client.options?.livevalidation && client.options.modeluri === modelURI);
+        return this.hasSubscribers(modelURI, 'livevalidation');
     }
 
     protected getValidationSubscribers(modelURI: string): JSONSocket[] {
-        return Array.from(this.subscriptions.keys()).filter(
-            client => client.options?.livevalidation && client.options.modeluri === modelURI
-        );
+        return this.getSubscribers(modelURI, 'livevalidation');
     }
 
     async broadcastValidation(modelURI: string, results: Diagnostic): Promise<boolean> {
@@ -98,20 +164,39 @@ export class SubscriptionManager {
             type: MessageType.validationResult,
             data: results
         };
-        return Promise.all(
-            this.getValidationSubscribers(modelURI).map(
-                client =>
-                    new Promise<boolean>(resolve => {
-                        client.send(message, (error?: Error) => {
-                            if (error) {
-                                this.logger.error('Failed to send subscription message.', error);
-                                resolve(false);
-                            } else {
-                                resolve(true);
-                            }
-                        });
-                    })
-            )
-        ).then(sent => sent.every(each => each));
+
+        return Promise.all(this.getValidationSubscribers(modelURI).map(client => this.sendSubscriptionMessage(client, message))).then(
+            sent => sent.every(each => each)
+        );
+    }
+
+    async sendValidation(client: JSONSocket, results: Diagnostic): Promise<boolean> {
+        const message = {
+            type: MessageType.validationResult,
+            data: results
+        };
+        return this.sendSubscriptionMessage(client, message);
+    }
+
+    protected async sendSubscriptionMessage(client: JSONSocket, message: ModelServerMessage<any>): Promise<boolean> {
+        return new Promise<boolean>(resolve => {
+            client.send(message, (error?: Error) => {
+                if (error) {
+                    this.logger.error('Failed to send subscription message.', error);
+                    resolve(false);
+                } else {
+                    resolve(true);
+                }
+            });
+        });
     }
 }
+
+const subscriberFilter: (
+    filter?: keyof SubscriptionQuery | ((options: SubscriptionQuery) => boolean)
+) => (client: Client) => boolean = filter =>
+    typeof filter === 'string'
+        ? client => !!client.options?.[filter]
+        : typeof filter === 'function'
+        ? client => client.options && filter(client.options)
+        : () => true;


### PR DESCRIPTION
Add a listener API for clients such as the `ValidationManager` to learn when subscriptions are added/removed. Update the `ValidationManager` to use this event to report the initial validation state to a new subscriber.

Some additional fixes are included in the `SubscriptionManager` to support this and similar use cases in subclasses:

- export the `SubscriptionQuery` type used in public/protected method signatures
- provide convenient access to subscribers, including filtering on subscription options
- provide API for sending messages to subscribers

Resolves #34.

Contributed on behalf of STMicroelectronics.
