### PR TITLE
Models router too specific about forwarding commands

### DIFF
--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -17,8 +17,10 @@ import {
     Model,
     ModelServerClientV2,
     ModelServerCommand,
+    ModelServerCommandPackage,
     ModelServerMessage,
     ModelServerNotification,
+    ModelServerObject,
     ModelUpdateResult,
     ServerConfiguration,
     SubscriptionListener,
@@ -477,7 +479,7 @@ class DefaultTransactionContext implements TransactionContext {
                 return this.popNestedContext();
             } else {
                 // It's a substitute command or patch. Just pass it on in the usual way
-                if (ModelServerCommand.is(provided)) {
+                if (isModelServerCommand(provided)) {
                     return this.sendCommand(provided);
                 }
                 return this.sendPatch(provided);
@@ -654,3 +656,13 @@ class DefaultTransactionContext implements TransactionContext {
 
 // A model update result indicating that the transaction was already closed or was rolled back
 const transactionClosed: ModelUpdateResult = { success: false };
+
+/**
+ * Query whether an `object` is any kind of `ModelServerCommand`.
+ *
+ * @param object an object
+ * @returns whether it is a `ModelServerCommand` of some kind
+ */
+export function isModelServerCommand(object: any): object is ModelServerCommand {
+    return ModelServerObject.is(object) && object.eClass.startsWith(ModelServerCommandPackage.NS_URI + '#//');
+}

--- a/packages/modelserver-node/src/routes/models.ts
+++ b/packages/modelserver-node/src/routes/models.ts
@@ -14,8 +14,6 @@ import {
     CompoundCommand,
     encode,
     ModelServerCommand,
-    ModelServerCommandPackage,
-    ModelServerObject,
     ModelUpdateResult,
     RemoveCommand,
     SetCommand
@@ -26,7 +24,7 @@ import { Operation } from 'fast-json-patch';
 import { ServerResponse } from 'http';
 import { inject, injectable, named } from 'inversify';
 
-import { ExecuteMessageBody, InternalModelServerClientApi, TransactionContext } from '../client/model-server-client';
+import { ExecuteMessageBody, InternalModelServerClientApi, isModelServerCommand, TransactionContext } from '../client/model-server-client';
 import { CommandProviderRegistry } from '../command-provider-registry';
 import { ValidationManager } from '../services/validation-manager';
 import { TriggerProviderRegistry } from '../trigger-provider-registry';
@@ -181,7 +179,7 @@ export class ModelsRoutes implements RouteProvider {
             // It's a substitute command or JSON Patch. Just execute/apply it in the usual way
             let result: Promise<ModelUpdateResult>;
 
-            if (ModelServerCommand.is(providedEdit)) {
+            if (isModelServerCommand(providedEdit)) {
                 // Command case
                 result = this.modelServerClient.edit(modelURI, providedEdit);
             } else {
@@ -207,7 +205,7 @@ export class ModelsRoutes implements RouteProvider {
                 result = await providedEdit(executor);
             } else {
                 // It's a command or JSON Patch. Just execute/apply it in the usual way
-                if (ModelServerCommand.is(providedEdit)) {
+                if (isModelServerCommand(providedEdit)) {
                     // Command case
                     await executor.execute(modelURI, providedEdit);
                 } else {
@@ -314,10 +312,6 @@ function asModelServerCommand(command: any): ModelServerCommand | undefined {
     }
 
     return undefined;
-}
-
-function isModelServerCommand(object: any): object is ModelServerCommand {
-    return ModelServerObject.is(object) && object.eClass.startsWith(ModelServerCommandPackage.NS_URI + '#//');
 }
 
 function isCustomCommand(command: ModelServerCommand): boolean {


### PR DESCRIPTION
Guard for any kind of `ModelServerCommand`, not just that parent type specifically, when determined how to forward a `ModelServerCommand` to the EMF server.

Fixes #43

Contributed on behalf of STMicroelectronics.