### PR TITLE
#179 Consistently use URI object in APIs

### DIFF
--- a/packages/modelserver-node/package.json
+++ b/packages/modelserver-node/package.json
@@ -32,6 +32,7 @@
     "express-asyncify": "^1.0.1",
     "express-ws": "^5.0.2",
     "inversify": "^5.1.1",
+    "urijs": "^1.19.11",
     "winston": "^3.3.3",
     "ws": "^8.4.0"
   },
@@ -39,6 +40,7 @@
     "@types/express": "^4.17.13",
     "@types/express-ws": "^3.0.1",
     "@types/reflect-metadata": "^0.1.0",
+    "@types/urijs": "^1.19.19",
     "@types/winston": "^2.4.4",
     "@types/ws": "^8.2.2",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/modelserver-node/src/client/uri-utils.ts
+++ b/packages/modelserver-node/src/client/uri-utils.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+import * as URI from 'urijs';
+
+/**
+ * Obtain a valid modelURI from the given `modeluri` query parameter.
+ *
+ * @param modeluri a modeluri string query parameter
+ * @returns the transformed valid URI, throws an Error otherwise
+ */
+export function validateModelURI(modeluri?: string): URI {
+    if (!modeluri || modeluri === '') {
+        throw new Error('Model URI parameter is absent or empty.');
+    }
+    const modelURIParts = URI.parse(modeluri);
+    // Java Model Server does not deal correctly with full absolute file path
+    const modelURI = new URI(modelURIParts).protocol('');
+    return modelURI;
+}

--- a/packages/modelserver-node/src/client/web-socket-utils.ts
+++ b/packages/modelserver-node/src/client/web-socket-utils.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 import { AnyObject, IdentityMapper, MessageDataMapper, ModelServerMessage, TypeGuard } from '@eclipse-emfcloud/modelserver-client';
 import { Request } from 'express';
+import * as URI from 'urijs';
 import { Logger } from 'winston';
 import * as WebSocket from 'ws';
 
@@ -38,7 +39,7 @@ export namespace WSUpgradeRequest {
 
     /** Change an `http:` URL to a `ws:` URL. */
     export function toWebsocketURL(httpURL: string): string {
-        return httpURL.replace(/^[^:]+/, 'ws');
+        return new URI(httpURL).protocol('ws').toString();
     }
 }
 

--- a/packages/modelserver-node/src/di.ts
+++ b/packages/modelserver-node/src/di.ts
@@ -42,7 +42,7 @@ async function loadModules(): Promise<ContainerModule[]> {
 function modelServerModule(modelServerPort: number): ContainerModule {
     return new ContainerModule(bind => {
         bind(UpstreamConnectionConfig).toConstantValue({
-            baseURL: 'api/v2/',
+            baseURL: 'api/v2',
             serverPort: modelServerPort,
             hostname: 'localhost'
         });

--- a/packages/modelserver-node/src/routes/routes.ts
+++ b/packages/modelserver-node/src/routes/routes.ts
@@ -13,6 +13,33 @@ import { Response } from 'express';
 import { ServerResponse } from 'http';
 
 /**
+ * Return an uri related error response to the upstream client.
+ *
+ * @param res the upstream response stream
+ * @returns a function that takes an uri related error and reports it to the upstream client
+ */
+export function handleUriError(res: ServerResponse): (error: any) => void {
+    return error => respondUriError(res, error);
+}
+
+/**
+ * Return an uri related error response to the upstream client.
+ *
+ * @param res the upstream response stream
+ * @param error the uri related error to report
+ */
+export function respondUriError(res: ServerResponse, error: any): boolean {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    if (error.stack) {
+        res.write(JSON.stringify({ error: error.toString(), stackTrace: error.stack }));
+    } else {
+        res.write(JSON.stringify({ error: error.toString() }));
+    }
+    res.end();
+    return false;
+}
+
+/**
  * Return an error response to the upstream client.
  *
  * @param res the upstream response stream

--- a/packages/modelserver-node/src/server-integration-test.spec.ts
+++ b/packages/modelserver-node/src/server-integration-test.spec.ts
@@ -55,7 +55,7 @@ export namespace CoffeeMachine {
 /** A representation of the upstream _Model Server_, which may or may not be available to tests that need it. */
 class UpstreamServer {
     /** The upstream server's base URL. */
-    protected readonly baseURL = 'http://localhost:8081/api/v2/';
+    protected readonly baseURL = 'http://localhost:8081/api/v2';
 
     /**
      * Test whether the upstream server is available. If not, then call the `ifNot` call-back.
@@ -92,7 +92,7 @@ export class ServerFixture {
     protected server: ModelServer;
 
     constructor(protected readonly containerConfig?: (container: Container) => void) {
-        this.baseUrl = 'http://localhost:8082/api/v2/';
+        this.baseUrl = 'http://localhost:8082/api/v2';
         this.client = new ModelServerClientV2();
         this.client.initialize(this.baseUrl, 'json-v2');
 

--- a/packages/modelserver-node/src/server-module.ts
+++ b/packages/modelserver-node/src/server-module.ts
@@ -16,6 +16,7 @@ import {
     ModelServiceFactory
 } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { ContainerModule } from 'inversify';
+import * as URI from 'urijs';
 
 import { InternalModelServerClient, InternalModelServerClientApi } from './client/model-server-client';
 import { CommandProviderRegistry } from './command-provider-registry';
@@ -41,7 +42,7 @@ export default new ContainerModule(bind => {
     bind(EditService).toSelf().inSingletonScope();
     bind(DefaultModelService).toSelf();
     bind(ModelService).toService(DefaultModelService);
-    bind(ModelServiceFactory).toFactory(context => (modeluri: string) => {
+    bind(ModelServiceFactory).toFactory(context => (modeluri: URI) => {
         const child = context.container.createChild();
         child.bind(MODEL_URI).toConstantValue(modeluri);
         return child.get(ModelService);

--- a/packages/modelserver-node/src/services/model-service.spec.ts
+++ b/packages/modelserver-node/src/services/model-service.spec.ts
@@ -410,7 +410,6 @@ describe('DefaultModelService', () => {
             const model = await newModelService.create(modelContent);
             assumeThat(!!model, 'Model not created.');
 
-            // FIXME subscription is not triggered in listenForFullUpdate
             const { ready, done: closed } = listenForFullUpdate(client, newModelURI, 'close');
             await ready;
 
@@ -444,7 +443,6 @@ describe('DefaultModelService', () => {
                         }
                     }
                 };
-                // FIXME subscription is not triggered
                 client.subscribe(newModelURI.toString(), new NotificationSubscriptionListenerV2(listener));
             });
 
@@ -463,7 +461,6 @@ describe('DefaultModelService', () => {
             const model = await newModelService.create(modelContent);
             assumeThat(!!model, 'Model not created.');
 
-            // FIXME subscription is not triggered in listenForFullUpdate
             const { ready, done: deleted } = listenForFullUpdate(client, newModelURI, 'delete');
             await ready;
 
@@ -593,7 +590,6 @@ function listenForFullUpdate(
                 onOpen: () => resolveListening(true),
                 onClose: pass
             };
-            // FIXME subscription is not triggered
             client.subscribe(modelURI.toString(), listener);
         });
     });

--- a/packages/modelserver-node/src/services/model-service.ts
+++ b/packages/modelserver-node/src/services/model-service.ts
@@ -20,6 +20,7 @@ import {
 import { EditTransaction, Logger, ModelService } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Operation } from 'fast-json-patch';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { EditService } from './edit-service';
@@ -35,7 +36,7 @@ export class DefaultModelService implements ModelService {
     protected readonly logger: Logger;
 
     @inject(MODEL_URI)
-    protected readonly modeluri: string;
+    protected readonly modeluri: URI;
 
     @inject(InternalModelServerClientApi)
     protected readonly client: InternalModelServerClientApi;
@@ -46,7 +47,7 @@ export class DefaultModelService implements ModelService {
     @inject(EditService)
     protected readonly editService: EditService;
 
-    getModelURI(): string {
+    getModelURI(): URI {
         return this.modeluri;
     }
 
@@ -55,40 +56,40 @@ export class DefaultModelService implements ModelService {
     getModel<M>(typeGuardOrFormat: TypeGuard<M> | string, format?: string): Promise<M | AnyObject> {
         if (typeof typeGuardOrFormat === 'string') {
             // It's the first signature with a format
-            return this.client.get(this.getModelURI(), typeGuardOrFormat);
+            return this.client.get(this.getModelURI().toString(), typeGuardOrFormat);
         }
         if (typeGuardOrFormat) {
             // It's the second signature and the format is easy to default
-            return this.client.get(this.getModelURI(), typeGuardOrFormat, format ?? FORMAT_JSON_V2);
+            return this.client.get(this.getModelURI().toString(), typeGuardOrFormat, format ?? FORMAT_JSON_V2);
         }
         // It's the first signature without a format
-        return this.client.get(this.getModelURI(), FORMAT_JSON_V2);
+        return this.client.get(this.getModelURI().toString(), FORMAT_JSON_V2);
     }
 
     edit(patch: Operation | Operation[]): Promise<ModelUpdateResult>;
     edit(command: ModelServerCommand): Promise<ModelUpdateResult>;
     edit(patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<ModelUpdateResult> {
-        return this.editService.edit(this.getModelURI(), patchOrCommand);
+        return this.editService.edit(this.getModelURI().toString(), patchOrCommand);
     }
 
     undo(): Promise<ModelUpdateResult> {
-        return this.client.undo(this.getModelURI());
+        return this.client.undo(this.getModelURI().toString());
     }
 
     redo(): Promise<ModelUpdateResult> {
-        return this.client.redo(this.getModelURI());
+        return this.client.redo(this.getModelURI().toString());
     }
 
     openTransaction(): Promise<EditTransaction> {
-        return this.client.openTransaction(this.getModelURI());
+        return this.client.openTransaction(this.getModelURI().toString());
     }
 
     validate(): Promise<Diagnostic> {
-        return this.validator.validate(this.getModelURI());
+        return this.validator.validate(this.getModelURI().toString());
     }
 
     async create<M extends AnyObject>(content: M, format?: string): Promise<M> {
-        return this.client.create(this.getModelURI(), content, format ?? FORMAT_JSON_V2).then(success => {
+        return this.client.create(this.getModelURI().toString(), content, format ?? FORMAT_JSON_V2).then(success => {
             if (success) {
                 return content;
             }
@@ -97,14 +98,14 @@ export class DefaultModelService implements ModelService {
     }
 
     save(): Promise<boolean> {
-        return this.client.save(this.getModelURI());
+        return this.client.save(this.getModelURI().toString());
     }
 
     close(): Promise<boolean> {
-        return this.client.close(this.getModelURI());
+        return this.client.close(this.getModelURI().toString());
     }
 
     delete(): Promise<boolean> {
-        return this.client.delete(this.getModelURI());
+        return this.client.delete(this.getModelURI().toString());
     }
 }

--- a/packages/modelserver-plugin-ext/src/model-service.ts
+++ b/packages/modelserver-plugin-ext/src/model-service.ts
@@ -11,6 +11,7 @@
 
 import { AnyObject, Diagnostic, Format, ModelServerCommand, ModelUpdateResult, TypeGuard } from '@eclipse-emfcloud/modelserver-client';
 import { Operation } from 'fast-json-patch';
+import * as URI from 'urijs';
 
 export const ModelServiceFactory = Symbol('ModelServiceFactory');
 export const ModelService = Symbol('ModelService');
@@ -18,7 +19,7 @@ export const ModelService = Symbol('ModelService');
 /**
  * A factory that obtains the `ModelService` for a particular model URI.
  */
-export type ModelServiceFactory = (modeluri: string) => ModelService;
+export type ModelServiceFactory = (modeluri: URI) => ModelService;
 
 /**
  * A service that plug-in extensions may use to create, access, and modify a model.
@@ -37,7 +38,7 @@ export interface ModelService {
      *
      * @returns my model's URI
      */
-    getModelURI(): string;
+    getModelURI(): URI;
 
     /**
      * Get the content of my model. If the `format` is omitted and a request needs to be

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
+"@types/urijs@^1.19.19":
+  version "1.19.19"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
+  integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
+
 "@types/winston@^2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/winston/-/winston-2.4.4.tgz#48cc744b7b42fad74b9a2e8490e0112bd9a3d08d"
@@ -5992,6 +5997,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
- Use `urijs` as typed URI library
- Use URI objects internally for URI handling

Part of https://github.com/eclipse-emfcloud/emfcloud/issues/179