### PR TITLE
179: Add missing dependency to urijs in plugin-ext

### DIFF
--- a/packages/modelserver-plugin-ext/package.json
+++ b/packages/modelserver-plugin-ext/package.json
@@ -30,10 +30,12 @@
     "express-ws": "^5.0.2",
     "fast-json-patch": "^3.1.0",
     "inversify": "^5.1.1",
+    "urijs": "^1.19.11",
     "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/reflect-metadata": "^0.1.0",
+    "@types/urijs": "^1.19.19",
     "@types/winston": "^2.4.4",
     "eslint-config-prettier": "^8.3.0",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
Additional change to https://github.com/eclipse-emfcloud/modelserver-node/pull/53 :

modelserver-plugin-ext references the urijs URI class in model-service, but doesn't actually contain a dependency to urijs. The dependency is only specified on modelserver-node, but plugin-ext doesn't depend on this package.

This PR adds an explicit dependency from modelserver-plugin-ext to urijs