### PR TITLE
179: Convert all Modelserver-Node APIs to use URI instead of String

### DIFF
--- a/examples/custom-command-example/src/example-command.ts
+++ b/examples/custom-command-example/src/example-command.ts
@@ -20,6 +20,7 @@ import {
     Transaction
 } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 
 /**
  * A simple example of a plug-in that provides custom commands.
@@ -52,7 +53,7 @@ class IncrementDurationCommandProvider implements CommandProvider {
         return true; // The command type filter is all I need
     }
 
-    getCommands(_modelUri: string, customCommand: ModelServerCommand): Transaction {
+    getCommands(_modelUri: URI, customCommand: ModelServerCommand): Transaction {
         const [modelURI, elementID] = customCommand.owner.$ref.split('#');
 
         return async executor => {

--- a/examples/custom-validator-example/src/example-validator.ts
+++ b/examples/custom-validator-example/src/example-validator.ts
@@ -19,6 +19,7 @@ import {
     ValidationProvider
 } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 
 /**
  * A simple example of a plug-in that provides custom validation.
@@ -47,11 +48,11 @@ export class ExampleCustomValidationPlugin implements ModelServerPlugin {
 class CoffeeMachineValidator implements ValidationProvider {
     constructor(protected readonly modelServerClient: ModelServerClientApi, protected readonly logger: Logger) {}
 
-    canValidate(model: ModelServerObjectV2, modelURI: string): boolean {
+    canValidate(model: ModelServerObjectV2, modelURI: URI): boolean {
         return true; // Nothing further to check than the pattern supplied at registration
     }
 
-    validate(model: ModelServerObjectV2, modelURI: string): Diagnostic {
+    validate(model: ModelServerObjectV2, modelURI: URI): Diagnostic {
         const probabilityTest = Math.random();
         if (probabilityTest < 0.5) {
             return Diagnostic.ok();

--- a/packages/modelserver-node/src/command-provider-registry.spec.ts
+++ b/packages/modelserver-node/src/command-provider-registry.spec.ts
@@ -12,6 +12,7 @@ import { ModelServerCommand, replace } from '@eclipse-emfcloud/modelserver-clien
 import { CommandProvider, Logger, Transaction } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { expect } from 'chai';
 import { Container } from 'inversify';
+import * as URI from 'urijs';
 
 import { CommandProviderRegistry } from './command-provider-registry';
 
@@ -52,7 +53,7 @@ class TestCommandProvider implements CommandProvider {
         return true;
     }
 
-    getCommands(_modelUri: string, customCommand: ModelServerCommand): Transaction {
+    getCommands(_modelUri: URI, customCommand: ModelServerCommand): Transaction {
         if (!customCommand.owner) {
             console.error('custom command owner was unexpectedly undefined');
             return async () => false;

--- a/packages/modelserver-node/src/command-provider-registry.ts
+++ b/packages/modelserver-node/src/command-provider-registry.ts
@@ -13,6 +13,7 @@ import { AddCommand, ModelServerCommand, RemoveCommand, SetCommand } from '@ecli
 import { CommandProvider, Logger, Transaction } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Operation } from 'fast-json-patch';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 
 /**
  * A registry of command providers from _Model Server_ plug-ins.

--- a/packages/modelserver-node/src/command-provider-registry.ts
+++ b/packages/modelserver-node/src/command-provider-registry.ts
@@ -93,7 +93,7 @@ export class CommandProviderRegistry {
      * @returns the provided command, command transaction, or the original `customCommand` standing in for itself
      *    if no provider can handle the custom command
      */
-    async getCommands(modelUri: string, customCommand: ModelServerCommand): Promise<ModelServerCommand | Operation[] | Transaction> {
+    async getCommands(modelUri: URI, customCommand: ModelServerCommand): Promise<ModelServerCommand | Operation[] | Transaction> {
         let result: ModelServerCommand | Operation[] | Transaction | undefined;
         const provider = this.getProvider(customCommand);
         if (provider) {

--- a/packages/modelserver-node/src/routes/models.ts
+++ b/packages/modelserver-node/src/routes/models.ts
@@ -105,7 +105,7 @@ export class ModelsRoutes implements RouteProvider {
                 ? this.modelServerClient.create(modeluri.toString(), model, format)
                 : this.modelServerClient.update(modeluri.toString(), model, format);
 
-            delegated.then(this.performModelValidation(modeluri.toString())).then(relay(res)).catch(handleError(res));
+            delegated.then(this.performModelValidation(modeluri)).then(relay(res)).catch(handleError(res));
         };
     }
 
@@ -146,7 +146,7 @@ export class ModelsRoutes implements RouteProvider {
         patchOrCommand: Operation | Operation[] | ModelServerCommand,
         res: Response<any, Record<string, any>>
     ): void {
-        this.editService.edit(modelURI.toString(), patchOrCommand).then(relay(res)).catch(handleError(res));
+        this.editService.edit(modelURI, patchOrCommand).then(relay(res)).catch(handleError(res));
     }
 
     /**
@@ -155,7 +155,7 @@ export class ModelsRoutes implements RouteProvider {
      * @param modelURI the model created or replaced
      * @returns the created or replacing model
      */
-    protected performModelValidation(modelURI: string): (delegatedResult: AnyObject) => Promise<AnyObject> {
+    protected performModelValidation(modelURI: URI): (delegatedResult: AnyObject) => Promise<AnyObject> {
         const validator = this.validationManager;
 
         return async (delegatedResult: AnyObject) => validator.performLiveValidation(modelURI).then(() => delegatedResult);

--- a/packages/modelserver-node/src/routes/undo-redo.ts
+++ b/packages/modelserver-node/src/routes/undo-redo.ts
@@ -12,6 +12,7 @@ import { ModelUpdateResult } from '@eclipse-emfcloud/modelserver-client/lib';
 import { Logger, RouteProvider, RouterFactory } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Request, RequestHandler, Response } from 'express';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { ValidationManager } from '../services/validation-manager';
@@ -69,11 +70,14 @@ export class UndoRedoRoutes implements RouteProvider {
                 ? this.modelServerClient.undo(modelURI)
                 : this.modelServerClient.redo(modelURI);
 
-            delegated.then(this.performLiveValidation(modelURI)).then(relay(res)).catch(handleError(res));
+            delegated
+                .then(this.performLiveValidation(new URI(modelURI)))
+                .then(relay(res))
+                .catch(handleError(res));
         };
     }
 
-    protected performLiveValidation(modelURI: string): (delegatedResult: ModelUpdateResult) => Promise<ModelUpdateResult> {
+    protected performLiveValidation(modelURI: URI): (delegatedResult: ModelUpdateResult) => Promise<ModelUpdateResult> {
         const validator = this.validationManager;
 
         return async (delegatedResult: ModelUpdateResult) => validator.performLiveValidation(modelURI).then(() => delegatedResult);

--- a/packages/modelserver-node/src/routes/validation.ts
+++ b/packages/modelserver-node/src/routes/validation.ts
@@ -11,6 +11,7 @@
 import { Logger, RouteProvider, RouterFactory } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Request, RequestHandler, Response } from 'express';
 import { inject, injectable, named } from 'inversify';
+import URI = require('urijs');
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { ValidationManager } from '../services/validation-manager';
@@ -67,7 +68,7 @@ export class ValidationRoutes implements RouteProvider {
                 return;
             }
 
-            this.validationManager.validate(modelURI).then(relay(res)).catch(handleError(res));
+            this.validationManager.validate(new URI(modelURI)).then(relay(res)).catch(handleError(res));
         };
     }
 }

--- a/packages/modelserver-node/src/routes/validation.ts
+++ b/packages/modelserver-node/src/routes/validation.ts
@@ -11,7 +11,7 @@
 import { Logger, RouteProvider, RouterFactory } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Request, RequestHandler, Response } from 'express';
 import { inject, injectable, named } from 'inversify';
-import URI = require('urijs');
+import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { ValidationManager } from '../services/validation-manager';

--- a/packages/modelserver-node/src/server-integration-test.spec.ts
+++ b/packages/modelserver-node/src/server-integration-test.spec.ts
@@ -25,6 +25,7 @@ import { Operation } from 'fast-json-patch';
 import { Container } from 'inversify';
 import * as sinon from 'sinon';
 import { assert } from 'sinon';
+import * as URI from 'urijs';
 import * as WebSocket from 'ws';
 
 import { InternalModelServerClientApi, TransactionContext } from './client/model-server-client';
@@ -262,7 +263,7 @@ describe('Server Integration Tests', () => {
         });
 
         beforeEach(async () => {
-            transaction = await client.openTransaction('SuperBrewer3000.coffee');
+            transaction = await client.openTransaction(new URI('SuperBrewer3000.coffee'));
         });
 
         afterEach(async () => {
@@ -281,7 +282,7 @@ describe('Server Integration Tests', () => {
 
         it('transaction already open', async () => {
             try {
-                const duplicate = await client.openTransaction('SuperBrewer3000.coffee');
+                const duplicate = await client.openTransaction(new URI('SuperBrewer3000.coffee'));
                 await duplicate.rollback('Should not have been opened.');
                 expect.fail('Should not have been able to open duplicate transaction.');
             } catch (error) {
@@ -371,7 +372,7 @@ describe('Server Integration Tests', () => {
         it('Transaction rolled back by failure', async () => {
             const patch: Operation = { op: 'replace', path: '/workflows/0/name', value: 'New Name' };
 
-            const transaction1 = await client.openTransaction('SuperBrewer3000.coffee');
+            const transaction1 = await client.openTransaction(new URI('SuperBrewer3000.coffee'));
 
             try {
                 await transaction1.applyPatch(patch);
@@ -386,7 +387,7 @@ describe('Server Integration Tests', () => {
             expect(transaction1.isOpen()).to.be.false;
 
             // Should be able to open a new transaction
-            const transaction2 = await client.openTransaction('SuperBrewer3000.coffee');
+            const transaction2 = await client.openTransaction(new URI('SuperBrewer3000.coffee'));
             expect(transaction2.isOpen()).to.be.true;
 
             try {

--- a/packages/modelserver-node/src/services/model-service.ts
+++ b/packages/modelserver-node/src/services/model-service.ts
@@ -69,7 +69,7 @@ export class DefaultModelService implements ModelService {
     edit(patch: Operation | Operation[]): Promise<ModelUpdateResult>;
     edit(command: ModelServerCommand): Promise<ModelUpdateResult>;
     edit(patchOrCommand: Operation | Operation[] | ModelServerCommand): Promise<ModelUpdateResult> {
-        return this.editService.edit(this.getModelURI().toString(), patchOrCommand);
+        return this.editService.edit(this.getModelURI(), patchOrCommand);
     }
 
     undo(): Promise<ModelUpdateResult> {
@@ -81,11 +81,11 @@ export class DefaultModelService implements ModelService {
     }
 
     openTransaction(): Promise<EditTransaction> {
-        return this.client.openTransaction(this.getModelURI().toString());
+        return this.client.openTransaction(this.getModelURI());
     }
 
     validate(): Promise<Diagnostic> {
-        return this.validator.validate(this.getModelURI().toString());
+        return this.validator.validate(this.getModelURI());
     }
 
     async create<M extends AnyObject>(content: M, format?: string): Promise<M> {

--- a/packages/modelserver-node/src/services/validation-manager.ts
+++ b/packages/modelserver-node/src/services/validation-manager.ts
@@ -12,6 +12,9 @@ import { Diagnostic, encode, ModelServerObjectV2 } from '@eclipse-emfcloud/model
 import { Logger } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { inject, injectable, named, postConstruct } from 'inversify';
 
+import { validateModelURI } from '../client/uri-utils';
+import URI = require('urijs');
+
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { JSONSocket } from '../client/web-socket-utils';
 import { ValidationProviderRegistry } from '../validation-provider-registry';
@@ -41,15 +44,15 @@ export class ValidationManager {
     initialize(): void {
         this.subscriptionManager.addSubscribedListener((client, params) => {
             if (params.livevalidation) {
-                this.initializeLiveValidation(client, params.modeluri);
+                this.initializeLiveValidation(client, validateModelURI(params.modeluri));
             }
         });
     }
 
-    async validate(modelURI: string): Promise<Diagnostic> {
+    async validate(modelURI: URI): Promise<Diagnostic> {
         let model: ModelServerObjectV2;
         try {
-            model = await this.modelServerClient.get(modelURI).then(asModelServerObject);
+            model = await this.modelServerClient.get(modelURI.toString()).then(asModelServerObject);
             if (!model) {
                 throw new Error(`Could not retrieve model '${modelURI}' to validate.`);
             }
@@ -59,7 +62,7 @@ export class ValidationManager {
         }
 
         this.logger.debug(`Performing core validation of ${modelURI}`);
-        const defaultDiagnostic = await this.modelServerClient.validate(modelURI);
+        const defaultDiagnostic = await this.modelServerClient.validate(modelURI.toString());
 
         this.logger.debug(`Performing custom validation of ${modelURI}`);
         const providedDiagnostic = await this.validationProviderRegistry.validate(model, modelURI);
@@ -75,7 +78,7 @@ export class ValidationManager {
      * @param modelURI the model URI to validate
      * @returns whether validation was successfully performed and broadcast (not whether it found no problems)
      */
-    async performLiveValidation(modelURI: string): Promise<boolean> {
+    async performLiveValidation(modelURI: URI): Promise<boolean> {
         // Short-circuit if there are no live validation subscribers
         if (!this.subscriptionManager.hasValidationSubscribers(modelURI)) {
             this.logger.debug(`No subscribers to live validation for ${modelURI}.`);
@@ -91,7 +94,7 @@ export class ValidationManager {
             });
     }
 
-    protected async initializeLiveValidation(client: JSONSocket, modelURI: string): Promise<unknown> {
+    protected async initializeLiveValidation(client: JSONSocket, modelURI: URI): Promise<unknown> {
         return this.validate(modelURI)
             .then(diagnostics => this.subscriptionManager.sendValidation(client, diagnostics))
             .catch(error => this.logger.error(`Failed to initialize live validation in subscription to ${modelURI}: ${error}`));

--- a/packages/modelserver-node/src/services/validation-manager.ts
+++ b/packages/modelserver-node/src/services/validation-manager.ts
@@ -11,11 +11,10 @@
 import { Diagnostic, encode, ModelServerObjectV2 } from '@eclipse-emfcloud/modelserver-client';
 import { Logger } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { inject, injectable, named, postConstruct } from 'inversify';
-
-import { validateModelURI } from '../client/uri-utils';
-import URI = require('urijs');
+import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
+import { validateModelURI } from '../client/uri-utils';
 import { JSONSocket } from '../client/web-socket-utils';
 import { ValidationProviderRegistry } from '../validation-provider-registry';
 import { SubscriptionManager } from './subscription-manager';

--- a/packages/modelserver-node/src/trigger-provider-registry.ts
+++ b/packages/modelserver-node/src/trigger-provider-registry.ts
@@ -12,6 +12,7 @@
 import { Executor, Logger, Transaction, TriggerProvider } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { Operation } from 'fast-json-patch';
 import { inject, injectable, named } from 'inversify';
+import * as URI from 'urijs';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -62,7 +63,7 @@ export class TriggerProviderRegistry {
         return this.providers.size > 0;
     }
 
-    getProviders(modelURI: string, patch: Operation[]): TriggerProvider[] {
+    getProviders(modelURI: URI, patch: Operation[]): TriggerProvider[] {
         this.logger.debug('Looking up trigger providers for JSON Patch');
         const result: TriggerProvider[] = [];
         for (const provider of this.providers.values()) {
@@ -81,7 +82,7 @@ export class TriggerProviderRegistry {
      * @returns an aggregate trigger provider, or `undefined` if no registered providers
      *    respond to the `patch`
      */
-    getProvider(modelURI: string, patch: Operation[]): TriggerProvider | undefined {
+    getProvider(modelURI: URI, patch: Operation[]): TriggerProvider | undefined {
         const providers = this.getProviders(modelURI, patch);
         switch (providers.length) {
             case 0:
@@ -100,7 +101,7 @@ export class TriggerProviderRegistry {
      * @param patch the JSON Patch on which to trigger further changes
      * @returns the provided trigger patch or transaction, if any
      */
-    async getTriggers(modelURI: string, patch: Operation[]): Promise<Operation[] | Transaction | undefined> {
+    async getTriggers(modelURI: URI, patch: Operation[]): Promise<Operation[] | Transaction | undefined> {
         let result: Operation[] | Transaction | undefined;
         const provider = this.getProvider(modelURI, patch);
         if (provider) {
@@ -124,7 +125,7 @@ export class TriggerProviderRegistry {
 function multiTriggerProvider(triggerProviders: TriggerProvider[]): TriggerProvider {
     return {
         canTrigger: () => true,
-        getTriggers: (modelURI: string, modelDelta: Operation[]) => async (executor: Executor) => {
+        getTriggers: (modelURI: URI, modelDelta: Operation[]) => async (executor: Executor) => {
             let result = true;
 
             for (const provider of triggerProviders) {

--- a/packages/modelserver-node/src/validation-provider-registry.ts
+++ b/packages/modelserver-node/src/validation-provider-registry.ts
@@ -12,7 +12,7 @@
 import { Diagnostic, ModelServerObjectV2, OK } from '@eclipse-emfcloud/modelserver-client';
 import { Logger, ValidationProvider, ValidationProviderRegistrationOptions } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { inject, injectable, named } from 'inversify';
-import URI = require('urijs');
+import * as URI from 'urijs';
 import { v4 as uuid } from 'uuid';
 
 type ValidationProviderFilter = (model: ModelServerObjectV2, modelURI: string) => boolean;

--- a/packages/modelserver-plugin-ext/src/command-provider.ts
+++ b/packages/modelserver-plugin-ext/src/command-provider.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 import { ModelServerCommand } from '@eclipse-emfcloud/modelserver-client';
+import * as URI from 'urijs';
 
 import { Transaction } from './executor';
 import { MaybePromise } from './util';
@@ -39,5 +40,5 @@ export interface CommandProvider {
      * @returns either a command to substitute for the custom command (perhaps a compound command) or a
      *     transaction that should be run in the context of a transactional compound command {@link Executor}
      */
-    getCommands(modelUri: string, customCommand: ModelServerCommand): MaybePromise<ModelServerCommand | Transaction>;
+    getCommands(modelUri: URI, customCommand: ModelServerCommand): MaybePromise<ModelServerCommand | Transaction>;
 }

--- a/packages/modelserver-plugin-ext/src/executor.ts
+++ b/packages/modelserver-plugin-ext/src/executor.ts
@@ -11,6 +11,7 @@
 
 import { ModelServerCommand, ModelUpdateResult } from '@eclipse-emfcloud/modelserver-client';
 import { Operation } from 'fast-json-patch';
+import * as URI from 'urijs';
 
 /**
  * Protocol of a context in which commands may be executed and JSON patches applied.

--- a/packages/modelserver-plugin-ext/src/executor.ts
+++ b/packages/modelserver-plugin-ext/src/executor.ts
@@ -27,7 +27,7 @@ export interface Executor {
      * @param command a command to be executed on the model
      * @return the result of the command's execution
      */
-    execute(modelUri: string, command: ModelServerCommand): Promise<ModelUpdateResult>;
+    execute(modelUri: URI, command: ModelServerCommand): Promise<ModelUpdateResult>;
 
     /**
      * Apply a JSON patch to the model.

--- a/packages/modelserver-plugin-ext/src/model-service.ts
+++ b/packages/modelserver-plugin-ext/src/model-service.ts
@@ -159,7 +159,7 @@ export interface EditTransaction {
     /**
      * Query the URI of the model that this transaction edits.
      */
-    getModelURI(): string;
+    getModelURI(): URI;
 
     /**
      * Query whether the transaction is currently open.

--- a/packages/modelserver-plugin-ext/src/trigger-provider.ts
+++ b/packages/modelserver-plugin-ext/src/trigger-provider.ts
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 import { Operation } from 'fast-json-patch';
+import * as URI from 'urijs';
 
 import { Transaction } from './executor';
 import { MaybePromise } from './util';
@@ -35,7 +36,7 @@ export interface TriggerProvider {
      * @param patch a JSON Patch describing model changes performed by a triggering edit
      * @returns whether the provider has any edits to add to the given `patch`
      */
-    canTrigger(modelURI: string, patch: Operation[]): boolean;
+    canTrigger(modelURI: URI, patch: Operation[]): boolean;
 
     /**
      * Obtain follow-up edits triggered by the given `patch`. These may either be
@@ -48,5 +49,5 @@ export interface TriggerProvider {
      *     or a transaction that should be run in the context of a transactional
      *     compound command {@link Executor}
      */
-    getTriggers(modelURI: string, modelDelta: Operation[]): MaybePromise<Operation[] | Transaction>;
+    getTriggers(modelURI: URI, modelDelta: Operation[]): MaybePromise<Operation[] | Transaction>;
 }

--- a/packages/modelserver-plugin-ext/src/validation-provider.ts
+++ b/packages/modelserver-plugin-ext/src/validation-provider.ts
@@ -26,7 +26,7 @@ export interface ValidationProvider {
      * @param modelURI the URI of the model resource
      * @returns whether the provider can and will validate the given `model`
      */
-    canValidate(model: ModelServerObjectV2, modelURI: string): boolean;
+    canValidate(model: ModelServerObjectV2, modelURI: URI): boolean;
 
     /**
      * Validate the given `model`.
@@ -35,5 +35,5 @@ export interface ValidationProvider {
      * @param modelURI the URI of the model resource
      * @returns the result of validation of the `model`
      */
-    validate(model: ModelServerObjectV2, modelURI: string): MaybePromise<Diagnostic>;
+    validate(model: ModelServerObjectV2, modelURI: URI): MaybePromise<Diagnostic>;
 }

--- a/packages/modelserver-plugin-ext/src/validation-provider.ts
+++ b/packages/modelserver-plugin-ext/src/validation-provider.ts
@@ -10,9 +10,9 @@
  *******************************************************************************/
 
 import { Diagnostic, ModelServerObjectV2 } from '@eclipse-emfcloud/modelserver-client';
+import * as URI from 'urijs';
 
 import { MaybePromise } from './util';
-
 /**
  * Protocol for a provider of custom validation rules that may be registered by a _Model Server_ plug-in.
  */


### PR DESCRIPTION
- Convert all public Modelserver-Node APIs to URI. This especially includes Providers and Services

refs https://github.com/eclipse-emfcloud/emfcloud/issues/179

Contributed on behalf of STMicroelectronics

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>