### PR TITLE
#179 Fix modelUri type in transaction message

### DIFF
--- a/packages/modelserver-node/src/client/model-server-client.ts
+++ b/packages/modelserver-node/src/client/model-server-client.ts
@@ -19,7 +19,6 @@ import {
     ModelServerCommand,
     ModelServerCommandPackage,
     ModelServerMessage,
-    ModelServerNotification,
     ModelServerObject,
     ModelUpdateResult,
     ServerConfiguration,
@@ -88,8 +87,9 @@ export interface TransactionContext extends Executor, EditTransaction {
 /**
  * Protocol of messages sent to and received from the _Model Server_ on a transaction socket.
  */
-export interface ModelServerTransactionMessage<T = unknown> extends ModelServerMessage<T>, ModelServerNotification {
+export interface ModelServerTransactionMessage<T = unknown> extends ModelServerMessage<T> {
     type: 'execute' | 'close' | 'roll-back' | 'incrementalUpdate' | 'success';
+    modeluri: string;
 }
 
 export type MessageBody = ModelServerTransactionMessage;
@@ -681,7 +681,7 @@ class DefaultTransactionContext implements TransactionContext {
     protected message(type: MessageBody['type'], data: unknown = {}): MessageBody {
         return {
             type,
-            modeluri: this.modelURI,
+            modeluri: this.modelURI.toString(),
             data
         };
     }


### PR DESCRIPTION
The transaction message for direct socket communication should send the `modelUri` as string instead of an URI object

Part of eclipse-emfcloud/emfcloud#179

Contributed on behalf of STMicroelectronics