### PR TITLE
#179 Consistently use URI object in APIs

### DIFF
--- a/packages/modelserver-node/README.md
+++ b/packages/modelserver-node/README.md
@@ -20,12 +20,19 @@ routerFactory('/api/v2(my-endpoint').get('/', myInterceptingHandler());
 This intercepting handler can:
 
 - handle the request by executing custom behaviour and not forwarding
-  - e.g. the [Validation RouteProvider](./src/routes/validation.ts)) delegates to the validation manager and stops the chain there
+  - the [Validation RouteProvider](./src/routes/validation.ts)) delegates to the validation manager and stops the chain there
 - handle the request by executing custom behaviour and forwarding to the next upstream
-  - e.g. executing custom behaviour and then forward to the next upstream via `return next();` (see also example below)
+  - executing custom behaviour and then forward to the next upstream via `return next();` (see also example below)
 - simply forward to the next upstream without any custom behaviour
-  - e.g. the [ModelElement RouteProvider](./src/routes/modelelement.ts)) forwards directly to the next upstream via `return next();`
-  - To only forward with a validated model uri, you may use the utility forwarding function `forwardWithValidatedModelUri`.
+  - forward directly to the next upstream via `return next();`. Please keep in mind that forwarding uses the requests'url to forward to the next upstream.
+- pass and stop execution
+  - if no custom behaviour is executed and no forward to upstream is triggered, the chain ends here
+
+Important: If the chain is stopped by your route provider, please always ensure that the execution is also formally ended and a response is sent:
+
+```ts
+res.end();
+```
 
 ### Model Uri Validation
 
@@ -35,7 +42,7 @@ The [`route-utils`](./src/routes/route-utils.ts) provides a utility wrapper hook
 export function myInterceptingHandler(): ModelRequestHandler {
     return async (req: ModelRequest, res: Response, next: NextFunction) => {
         withValidatedModelUri(req, res, async validatedModelUri => {
-            // do some custom behaviour
+            // execute some custom behaviour with the validated model uri
             ...
             // AND/OR forward request to upstream with validated model uri
             return next();

--- a/packages/modelserver-node/README.md
+++ b/packages/modelserver-node/README.md
@@ -5,3 +5,45 @@ This package provides the _Model Server_ server framework.
 ## Setup
 
 See the [parent readme](../../README.md) for details of how to set up and build the project.
+
+## Routing Mechanism
+
+Route providers create interceptors for endpoints (`GET/POST/PUT..`) via the `routerfactory`:
+
+```ts
+routerFactory('/api/v2/my-endpoint', myInterceptingHandler().bind(this));
+```
+
+This intercepting handler can:
+
+- handle the request by executing custom behaviour and not forwarding
+  - e.g. the [Validation RouteProvider](./src/routes/validation.ts)) delegates to the validation manager and stops the chain there
+- handle the request by executing custom behaviour and forwarding to the next upstream
+  - e.g. the [UndoRedo RouteProvider](./src/routes/undo-redo.ts)) delegates to the validation manager and stops the chain
+- simply forward to the next upstream without any custom behaviour
+  - e.g. the [ModelElement RouteProvider](./src/routes/modelelement.ts)) forwards directly to the next upstream via `return next();`
+  - To only forward with a validated model uri, you may use the utility forwarding function `forwardWithValidatedModelUri`.
+
+### Model Uri Validation
+
+The [`route-utils`](./src/routes/route-utils.ts) provides a utility wrapper hook that validates the model uri beforehand and passes it on to the intercepting handler via:
+
+```ts
+export function myInterceptingHandler(): ModelRequestHandler {
+    return async (req: ModelRequest, res: Response, next: NextFunction) => {
+        withValidatedModelUri(req, res, async validatedModelUri => {
+            // do some custom behaviour
+            ...
+            // AND/OR forward request to upstream with validated model uri
+            return next();
+        });
+    };
+}
+```
+
+This example uses the validated model uri in some custom behaviour, and eventually forwards the request to the next upstream (via `return next()`).
+
+### Binding of Route Providers
+
+The default route providers are currently all bound in [one container module](./src/routes/routing-module.ts)
+This is not optimal and unconvenient, for more details please see [Issue #64](https://github.com/eclipse-emfcloud/modelserver-node/issues/64) which aims to improve the module handling.

--- a/packages/modelserver-node/README.md
+++ b/packages/modelserver-node/README.md
@@ -19,7 +19,7 @@ This intercepting handler can:
 - handle the request by executing custom behaviour and not forwarding
   - e.g. the [Validation RouteProvider](./src/routes/validation.ts)) delegates to the validation manager and stops the chain there
 - handle the request by executing custom behaviour and forwarding to the next upstream
-  - e.g. the [UndoRedo RouteProvider](./src/routes/undo-redo.ts)) delegates to the validation manager and stops the chain
+  - e.g. executing custom behaviour and then forward to the next upstream via `return next();` (see also example below)
 - simply forward to the next upstream without any custom behaviour
   - e.g. the [ModelElement RouteProvider](./src/routes/modelelement.ts)) forwards directly to the next upstream via `return next();`
   - To only forward with a validated model uri, you may use the utility forwarding function `forwardWithValidatedModelUri`.

--- a/packages/modelserver-node/README.md
+++ b/packages/modelserver-node/README.md
@@ -8,10 +8,13 @@ See the [parent readme](../../README.md) for details of how to set up and build 
 
 ## Routing Mechanism
 
-Route providers create interceptors for endpoints (`GET/POST/PUT..`) via the `routerfactory`:
+Route providers create interceptors for endpoints (`GET/POST/PUT..`) via the `routerFactory`:
 
 ```ts
-routerFactory('/api/v2/my-endpoint', myInterceptingHandler().bind(this));
+const router = routerFactory('/api/v2');
+router.get('/my-endpoint', myInterceptingHandler());
+// OR
+routerFactory('/api/v2(my-endpoint').get('/', myInterceptingHandler());
 ```
 
 This intercepting handler can:

--- a/packages/modelserver-node/src/client/uri-utils.ts
+++ b/packages/modelserver-node/src/client/uri-utils.ts
@@ -16,12 +16,27 @@ import * as URI from 'urijs';
  * @param modeluri a modeluri string query parameter
  * @returns the transformed valid URI, throws an Error otherwise
  */
-export function validateModelURI(modeluri?: string): URI {
-    if (!modeluri || modeluri === '') {
-        throw new Error('Model URI parameter is absent or empty.');
+export function getValidatedModelURI(queryModelUri?: string): URI {
+    if (!queryModelUri || queryModelUri === '') {
+        throw new Error('Model uri parameter is absent or empty.');
     }
-    const modelURIParts = URI.parse(modeluri);
-    // Java Model Server does not deal correctly with full absolute file path
-    const modelURI = new URI(modelURIParts).protocol('');
-    return modelURI;
+    if (typeof queryModelUri !== 'string') {
+        throw new Error(`Incorrect query model uri parameter: ${queryModelUri}`);
+    }
+    return getNormalizedUri(queryModelUri);
+}
+
+/**
+ * Returns the given uri string as normalized URI object
+ * @param uriString the uri as string to be normalized
+ * @returns the normalized URI
+ */
+export function getNormalizedUri(uriString: string): URI {
+    return new URI(cleanWindowsPath(uriString)).normalize();
+}
+
+function cleanWindowsPath(path: string): string {
+    // if the path begins with forward or backward slashes, followed by a drive letter,
+    // clean the slashes from the beginning of the string as it's not a valid absolute path in Windows
+    return path.replace(/^([\\/]+)([a-zA-Z]+:[\\/]+.*)/g, '$2');
 }

--- a/packages/modelserver-node/src/client/uri-utils.ts
+++ b/packages/modelserver-node/src/client/uri-utils.ts
@@ -16,7 +16,7 @@ import * as URI from 'urijs';
  * @param modeluri a modeluri string query parameter
  * @returns the transformed valid URI, throws an Error otherwise
  */
-export function getValidatedModelURI(queryModelUri?: string): URI {
+export function getValidatedModelUri(queryModelUri?: string): URI {
     if (!queryModelUri || queryModelUri === '') {
         throw new Error('Model uri parameter is absent or empty.');
     }
@@ -32,7 +32,7 @@ export function getValidatedModelURI(queryModelUri?: string): URI {
  * @returns the normalized URI
  */
 export function getNormalizedUri(uriString: string): URI {
-    return new URI(cleanWindowsPath(uriString)).normalize();
+    return new URI(cleanWindowsPath(uriString));
 }
 
 function cleanWindowsPath(path: string): string {

--- a/packages/modelserver-node/src/routes/index.ts
+++ b/packages/modelserver-node/src/routes/index.ts
@@ -8,8 +8,4 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
-
-export * from './di';
-export * from './routes';
-export * from './server';
-export * from './server-module';
+export * from './route-utils';

--- a/packages/modelserver-node/src/routes/modelelement.ts
+++ b/packages/modelserver-node/src/routes/modelelement.ts
@@ -35,6 +35,7 @@ export class ModelElementRoutes implements RouteProvider {
         /**
          * Create a `GET` request handler for the `/api/v2/modelelement` endpoint
          */
-        routerFactory('/api/v2/modelelement', forwardWithValidatedModelUri().bind(this));
+        const router = routerFactory('/api/v2');
+        router.get('/modelelement', forwardWithValidatedModelUri());
     }
 }

--- a/packages/modelserver-node/src/routes/modelelement.ts
+++ b/packages/modelserver-node/src/routes/modelelement.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+import { Logger, RouteProvider, RouterFactory } from '@eclipse-emfcloud/modelserver-plugin-ext';
+import { inject, injectable, named } from 'inversify';
+
+import { InternalModelServerClientApi } from '../client/model-server-client';
+import { forwardWithValidatedModelUri } from './route-utils';
+
+/**
+ * Custom routing of requests on the `/api/v2/modelelement` endpoint.
+ * The primary such customization is an intercept of the `GET` request for validation
+ * to delegate the implementation of custom validation providers.
+ *
+ * Intercepts model uri validation to be used to forward
+ * the base model element query behaviour to the _Upstream Model Server_.
+ */
+@injectable()
+export class ModelElementRoutes implements RouteProvider {
+    @inject(Logger)
+    @named(ModelElementRoutes.name)
+    protected readonly logger: Logger;
+
+    @inject(InternalModelServerClientApi)
+    protected readonly modelServerClient: InternalModelServerClientApi;
+
+    configureRoutes(routerFactory: RouterFactory): void {
+        /**
+         * Create a `GET` request handler for the `/api/v2/modelelement` endpoint
+         */
+        routerFactory('/api/v2/modelelement', forwardWithValidatedModelUri().bind(this));
+    }
+}

--- a/packages/modelserver-node/src/routes/route-utils.ts
+++ b/packages/modelserver-node/src/routes/route-utils.ts
@@ -13,7 +13,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { ServerResponse } from 'http';
 import * as URI from 'urijs';
 
-import { getValidatedModelURI } from '../client/uri-utils';
+import { getValidatedModelUri } from '../client/uri-utils';
 
 /**
  * Query parameters for requests to endpoints that require a `modeluri` parameter.
@@ -63,7 +63,7 @@ export function respondUriError(res: ServerResponse, error: any): boolean {
  */
 export function withValidatedModelUri(req: ModelRequest, res: Response, endpointHandler: (modeluri: URI) => void): void {
     try {
-        const validatedModelUri = getValidatedModelURI(req.query.modeluri);
+        const validatedModelUri = getValidatedModelUri(req.query.modeluri);
         if (!validatedModelUri) {
             throw new Error('Validated Model URI is absent or empty.');
         }

--- a/packages/modelserver-node/src/routes/routing-module.ts
+++ b/packages/modelserver-node/src/routes/routing-module.ts
@@ -12,6 +12,7 @@
 import { RouteProvider } from '@eclipse-emfcloud/modelserver-plugin-ext';
 import { ContainerModule } from 'inversify';
 
+import { ModelElementRoutes } from './modelelement';
 import { ModelsRoutes } from './models';
 import { SubscriptionRoutes } from './subscription';
 import { UndoRedoRoutes } from './undo-redo';
@@ -19,6 +20,7 @@ import { ValidationRoutes } from './validation';
 
 export default new ContainerModule(bind => {
     bind(RouteProvider).to(ModelsRoutes);
+    bind(RouteProvider).to(ModelElementRoutes);
     bind(RouteProvider).to(ValidationRoutes);
     bind(RouteProvider).to(UndoRedoRoutes);
     bind(RouteProvider).to(SubscriptionRoutes);

--- a/packages/modelserver-node/src/routes/undo-redo.ts
+++ b/packages/modelserver-node/src/routes/undo-redo.ts
@@ -10,21 +10,13 @@
  *******************************************************************************/
 import { ModelUpdateResult } from '@eclipse-emfcloud/modelserver-client/lib';
 import { Logger, RouteProvider, RouterFactory } from '@eclipse-emfcloud/modelserver-plugin-ext';
-import { Request, RequestHandler, Response } from 'express';
+import { Response } from 'express';
 import { inject, injectable, named } from 'inversify';
 import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
 import { ValidationManager } from '../services/validation-manager';
-import { handleError, relay } from './routes';
-
-/**
- * Query parameters for the `GET` request on the `undo` or `redo` endpoint.
- */
-interface UndoRedoGetQuery {
-    /** The model URI to undo/redo. */
-    modeluri: string;
-}
+import { handleError, ModelRequest, ModelRequestHandler, relay, withValidatedModelUri } from './route-utils';
 
 /**
  * Custom routing of requests on the `/api/v2/{undo,redo}` endpoints.
@@ -55,25 +47,21 @@ export class UndoRedoRoutes implements RouteProvider {
      *
      * @returns the undo/redo intercept handler
      */
-    protected interceptUndoRedoGet(): RequestHandler<unknown, any, any, UndoRedoGetQuery, Record<string, any>> {
-        return async (req: Request<unknown, any, any, UndoRedoGetQuery, Record<string, any>>, res: Response<any, Record<string, any>>) => {
-            const modelURI = req.query.modeluri?.trim();
-            if (!modelURI || modelURI === '') {
-                handleError(res)('Model URI parameter is absent or empty.');
-                return;
-            }
+    protected interceptUndoRedoGet(): ModelRequestHandler {
+        return async (req: ModelRequest, res: Response) => {
+            withValidatedModelUri(req, res, async validatedModelUri => {
+                const isUndo = req.path.startsWith('/undo');
+                this.logger.debug(`Delegating ${isUndo ? 'undo' : 'redo'} of ${validatedModelUri}.`);
 
-            const isUndo = req.path.startsWith('/undo');
-            this.logger.debug(`Delegating ${isUndo ? 'undo' : 'redo'} of ${modelURI}.`);
+                const delegated = isUndo //
+                    ? this.modelServerClient.undo(validatedModelUri)
+                    : this.modelServerClient.redo(validatedModelUri);
 
-            const delegated = isUndo //
-                ? this.modelServerClient.undo(modelURI)
-                : this.modelServerClient.redo(modelURI);
-
-            delegated
-                .then(this.performLiveValidation(new URI(modelURI)))
-                .then(relay(res))
-                .catch(handleError(res));
+                delegated //
+                    .then(this.performLiveValidation(validatedModelUri))
+                    .then(relay(res))
+                    .catch(handleError(res));
+            });
         };
     }
 

--- a/packages/modelserver-node/src/server.ts
+++ b/packages/modelserver-node/src/server.ts
@@ -193,13 +193,17 @@ export class ModelServer {
                 return;
             }
 
+            // In case we modified the model uri query param, we do not want to use the old req.url here
+            // We use the original url and the query params to form the request url to query the upstream model server
+            const originalURL = req.url.split('?')[0];
             const relayReq: AxiosRequestConfig = {
-                url: req.url,
+                url: originalURL,
+                params: req.query,
                 method: req.method.toUpperCase() as Method,
                 data: req.body
             };
 
-            this.logger.debug(`Forwarding ${req.method} request on ${req.url} to Upstream Model Server.`);
+            this.logger.debug(`Forwarding ${req.method} request on ${relayReq.url} to Upstream Model Server.`);
 
             upstream
                 .request(relayReq)

--- a/packages/modelserver-node/src/services/validation-manager.ts
+++ b/packages/modelserver-node/src/services/validation-manager.ts
@@ -14,7 +14,7 @@ import { inject, injectable, named, postConstruct } from 'inversify';
 import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
-import { validateModelURI } from '../client/uri-utils';
+import { getValidatedModelURI } from '../client/uri-utils';
 import { JSONSocket } from '../client/web-socket-utils';
 import { ValidationProviderRegistry } from '../validation-provider-registry';
 import { SubscriptionManager } from './subscription-manager';
@@ -43,7 +43,7 @@ export class ValidationManager {
     initialize(): void {
         this.subscriptionManager.addSubscribedListener((client, params) => {
             if (params.livevalidation) {
-                this.initializeLiveValidation(client, validateModelURI(params.modeluri));
+                this.initializeLiveValidation(client, getValidatedModelURI(params.modeluri));
             }
         });
     }

--- a/packages/modelserver-node/src/services/validation-manager.ts
+++ b/packages/modelserver-node/src/services/validation-manager.ts
@@ -14,7 +14,7 @@ import { inject, injectable, named, postConstruct } from 'inversify';
 import * as URI from 'urijs';
 
 import { InternalModelServerClientApi } from '../client/model-server-client';
-import { getValidatedModelURI } from '../client/uri-utils';
+import { getValidatedModelUri } from '../client/uri-utils';
 import { JSONSocket } from '../client/web-socket-utils';
 import { ValidationProviderRegistry } from '../validation-provider-registry';
 import { SubscriptionManager } from './subscription-manager';
@@ -43,7 +43,7 @@ export class ValidationManager {
     initialize(): void {
         this.subscriptionManager.addSubscribedListener((client, params) => {
             if (params.livevalidation) {
-                this.initializeLiveValidation(client, getValidatedModelURI(params.modeluri));
+                this.initializeLiveValidation(client, getValidatedModelUri(params.modeluri));
             }
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,9 +45,9 @@
     kuler "^2.0.0"
 
 "@eclipse-emfcloud/modelserver-client@next":
-  version "0.8.0-next.6238c88.78"
-  resolved "https://registry.yarnpkg.com/@eclipse-emfcloud/modelserver-client/-/modelserver-client-0.8.0-next.6238c88.78.tgz#26c8da84225d4da3d91be95f55e199e9c367228e"
-  integrity sha512-pUYdquw/3rvBPjeekIdZ3rH9z9SxGa89hxAaaQFBDknv8URIW+KdgRfA2O0v+H+xhQP8xesgiF6zFkd8FY3tRw==
+  version "0.8.0-next.0cdbeb3.84"
+  resolved "https://registry.yarnpkg.com/@eclipse-emfcloud/modelserver-client/-/modelserver-client-0.8.0-next.0cdbeb3.84.tgz#0731ef6f9e7a1f0bc563b4c0d048118aeac314e2"
+  integrity sha512-oI9q2x66Auw7kR0mUvytzU6CZBW8cf33MfiyM3Qnf85VeZ6UPhVT64SUEtDJ6iEgMd7mnCLsii0T9U5KNWC8VA==
   dependencies:
     axios "^0.24.0"
     events "^3.3.0"
@@ -962,17 +962,17 @@
     read-package-json-fast "^2.0.3"
     which "^2.0.2"
 
-"@nrwl/cli@15.2.3":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-15.2.3.tgz#3e1905f8d0143f23776eae59e311fcee62f0e20b"
-  integrity sha512-SUBTVl3/MKsE01x+4OaxZ6r4Mc6vshgU9xoSz6c4P23pvkMXsmVrFh8u2GcNS7/y5SvNWynzP61nLCXPPlO42w==
+"@nrwl/cli@15.3.3":
+  version "15.3.3"
+  resolved "https://registry.yarnpkg.com/@nrwl/cli/-/cli-15.3.3.tgz#9d7f09e336c39ecc54155f21f394b0fc740054eb"
+  integrity sha512-ZWTmVP9H3ukppWWGaS/s3Nym2nOYgnt6eHtuUFNsroz8LesG5oFAJviOz9jDEM/b+pLIrvYfU5aAGZqrtM3Z2A==
   dependencies:
-    nx "15.2.3"
+    nx "15.3.3"
 
 "@nrwl/devkit@>=14.8.6 < 16":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-15.2.3.tgz#70b4e914c4cd19cd1ba99389499ba854985a821e"
-  integrity sha512-3IZVahO6vvEFxp0N7mEO34ZnYT+8FaObyYI/2XVYZ0eDCAMihn2IIUMj+M42vAXPOJpctdghSKXovQDuHO031w==
+  version "15.3.3"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-15.3.3.tgz#8a038334cf5b563befdad4b201e0b146dfd2969a"
+  integrity sha512-48R9HAp6r6umWNXTlVTMsH94YYjU/XUPLDTtXBgKESMVbdq8Fk+HDHuN0thXG5dL6DFkXgD0MICLm3jSQU6xMw==
   dependencies:
     "@phenomnomnominal/tsquery" "4.1.1"
     ejs "^3.1.7"
@@ -980,12 +980,12 @@
     semver "7.3.4"
     tslib "^2.3.0"
 
-"@nrwl/tao@15.2.3":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-15.2.3.tgz#9b5a25f86280d9871f15cb09335b07b09b8bf454"
-  integrity sha512-er7VBy+NAOmQU16Od9rAkktpfhidn6lIK+eVRJIitTZAC8thT7MwqZRZVyLJiGE1iHs3h9EOs6LyCJpASqucjA==
+"@nrwl/tao@15.3.3":
+  version "15.3.3"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-15.3.3.tgz#b54a4f28833d11f96f69796b6d2c1624123734e5"
+  integrity sha512-f9+VwhlJ/7TWpjHSgoUOAA067uP9DmzABMY9HC5OREEDaCx+rzYEvbLAPv6cXzWw+6IYM6cyKw0zWSQrdEVrWg==
   dependencies:
-    nx "15.2.3"
+    nx "15.3.3"
 
 "@octokit/auth-token@^3.0.0":
   version "3.0.2"
@@ -1109,9 +1109,9 @@
     esquery "^1.0.1"
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.5.tgz#e280c94c95f206dcfd5aca00a43f2156b758c764"
-  integrity sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
+  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -1213,7 +1213,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.31":
   version "4.17.31"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
   integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
@@ -1232,12 +1232,12 @@
     "@types/ws" "*"
 
 "@types/express@*", "@types/express@^4.17.13":
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
-  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
+  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
+    "@types/express-serve-static-core" "^4.17.31"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -1279,9 +1279,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+  version "18.11.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.15.tgz#de0e1fbd2b22b962d45971431e2ae696643d3f5d"
+  integrity sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1360,20 +1360,20 @@
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
 "@types/yargs@^17.0.8":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.13.tgz#34cced675ca1b1d51fcf4d34c3c6f0fa142a5c76"
-  integrity sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.17.tgz#5672e5621f8e0fca13f433a8017aae4b7a2a03e7"
+  integrity sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==
   dependencies:
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.38.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz#696b9cc21dfd4749c1c8ad1307f76a36a00aa0e3"
-  integrity sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz#098abb4c9354e19f460d57ab18bff1f676a6cff0"
+  integrity sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.42.1"
-    "@typescript-eslint/type-utils" "5.42.1"
-    "@typescript-eslint/utils" "5.42.1"
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/type-utils" "5.46.1"
+    "@typescript-eslint/utils" "5.46.1"
     debug "^4.3.4"
     ignore "^5.2.0"
     natural-compare-lite "^1.4.0"
@@ -1382,71 +1382,71 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.38.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.42.1.tgz#3e66156f2f74b11690b45950d8f5f28a62751d35"
-  integrity sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.46.1.tgz#1fc8e7102c1141eb64276c3b89d70da8c0ba5699"
+  integrity sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.42.1"
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/typescript-estree" "5.42.1"
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/typescript-estree" "5.46.1"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz#05e5e1351485637d466464237e5259b49f609b18"
-  integrity sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==
+"@typescript-eslint/scope-manager@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz#70af8425c79bbc1178b5a63fb51102ddf48e104a"
+  integrity sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/visitor-keys" "5.42.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/visitor-keys" "5.46.1"
 
-"@typescript-eslint/type-utils@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz#21328feb2d4b193c5852b35aabd241ccc1449daa"
-  integrity sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==
+"@typescript-eslint/type-utils@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz#195033e4b30b51b870dfcf2828e88d57b04a11cc"
+  integrity sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.42.1"
-    "@typescript-eslint/utils" "5.42.1"
+    "@typescript-eslint/typescript-estree" "5.46.1"
+    "@typescript-eslint/utils" "5.46.1"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.42.1.tgz#0d4283c30e9b70d2aa2391c36294413de9106df2"
-  integrity sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==
+"@typescript-eslint/types@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.46.1.tgz#4e9db2107b9a88441c4d5ecacde3bb7a5ebbd47e"
+  integrity sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==
 
-"@typescript-eslint/typescript-estree@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz#f9a223ecb547a781d37e07a5ac6ba9ff681eaef0"
-  integrity sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==
+"@typescript-eslint/typescript-estree@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz#5358088f98a8f9939355e0996f9c8f41c25eced2"
+  integrity sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/visitor-keys" "5.42.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/visitor-keys" "5.46.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.42.1.tgz#2789b1cd990f0c07aaa3e462dbe0f18d736d5071"
-  integrity sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==
+"@typescript-eslint/utils@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.46.1.tgz#7da3c934d9fd0eb4002a6bb3429f33298b469b4a"
+  integrity sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==
   dependencies:
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.42.1"
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/typescript-estree" "5.42.1"
+    "@typescript-eslint/scope-manager" "5.46.1"
+    "@typescript-eslint/types" "5.46.1"
+    "@typescript-eslint/typescript-estree" "5.46.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz#df10839adf6605e1cdb79174cf21e46df9be4872"
-  integrity sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==
+"@typescript-eslint/visitor-keys@5.46.1":
+  version "5.46.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz#126cc6fe3c0f83608b2b125c5d9daced61394242"
+  integrity sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
+    "@typescript-eslint/types" "5.46.1"
     eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -1460,9 +1460,9 @@
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 "@yarnpkg/parsers@^3.0.0-rc.18":
-  version "3.0.0-rc.31"
-  resolved "https://registry.yarnpkg.com/@yarnpkg/parsers/-/parsers-3.0.0-rc.31.tgz#fbcce77c3783b2be8a381edf70bea3182e0b8b16"
-  integrity sha512-7M67TPmTM5OmtoypK0KHV3vIY9z0v4qZ6zF7flH8THLgjGuoA7naop8pEfL9x5vCtid1PDC4A4COrcym4WAZpQ==
+  version "3.0.0-rc.33"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/parsers/-/parsers-3.0.0-rc.33.tgz#4d8f46acd0db74a01732d2f6406ca8277e6f8027"
+  integrity sha512-az35wEPH00kW6eZDqHC0BumzAB4XD+YJb1b5tHEfsy73viCN7uGy8kvutwig5bgVwt1Hx7GuU09G50Sc5osBlA==
   dependencies:
     js-yaml "^3.10.0"
     tslib "^2.4.0"
@@ -1586,9 +1586,9 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
     color-convert "^2.0.1"
 
 anymatch@~3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
-  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -1712,9 +1712,9 @@ axios@^0.24.0:
     follow-redirects "^1.14.4"
 
 axios@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.0.tgz#1cb65bd75162c70e9f8d118a905126c4a201d383"
-  integrity sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.1.tgz#44cf04a3c9f0c2252ebd85975361c026cb9f864a"
+  integrity sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
@@ -2267,9 +2267,9 @@ core-util-is@~1.0.0:
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cosmiconfig@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -2366,9 +2366,9 @@ dedent@^0.7.0:
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
 deep-eql@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.2.tgz#270ceb902f87724077e6f6449aed81463f42fc1c"
-  integrity sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
   dependencies:
     type-detect "^4.0.0"
 
@@ -2581,9 +2581,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.19.0, es-abstract@^1.20.4:
-  version "1.20.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
-  integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
+  version "1.20.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.5.tgz#e6dc99177be37cacda5988e692c3fa8b218e95d2"
+  integrity sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -2591,6 +2591,7 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     function.prototype.name "^1.1.5"
     get-intrinsic "^1.1.3"
     get-symbol-description "^1.0.0"
+    gopd "^1.0.1"
     has "^1.0.3"
     has-property-descriptors "^1.0.0"
     has-symbols "^1.0.3"
@@ -2606,8 +2607,8 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     object.assign "^4.1.4"
     regexp.prototype.flags "^1.4.3"
     safe-regex-test "^1.0.0"
-    string.prototype.trimend "^1.0.5"
-    string.prototype.trimstart "^1.0.5"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
     unbox-primitive "^1.0.2"
 
 es-shim-unscopables@^1.0.0:
@@ -2762,9 +2763,9 @@ eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.3.0:
-  version "8.27.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.27.0.tgz#d547e2f7239994ad1faa4bb5d84e5d809db7cf64"
-  integrity sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==
+  version "8.29.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.29.0.tgz#d74a88a20fb44d59c51851625bc4ee8d0ec43f87"
+  integrity sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==
   dependencies:
     "@eslint/eslintrc" "^1.3.3"
     "@humanwhocodes/config-array" "^0.11.6"
@@ -3000,9 +3001,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.14.0.tgz#107f69d7295b11e0fccc264e1fc6389f623731ce"
+  integrity sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==
   dependencies:
     reusify "^1.0.4"
 
@@ -3214,7 +3215,7 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
   integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
@@ -3362,9 +3363,9 @@ glob@^8.0.1:
     once "^1.3.0"
 
 globals@^13.15.0:
-  version "13.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
-  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
+  version "13.19.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.19.0.tgz#7a42de8e6ad4f7242fbcca27ea5b23aca367b5c8"
+  integrity sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==
   dependencies:
     type-fest "^0.20.2"
 
@@ -3577,15 +3578,10 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.0.4:
+ignore@^5.0.4, ignore@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
   integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
-
-ignore@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
-  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -3671,11 +3667,11 @@ inquirer@^8.2.4:
     wrap-ansi "^7.0.0"
 
 internal-slot@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
-  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.4.tgz#8551e7baf74a7a6ba5f749cfb16aa60722f0d6f3"
+  integrity sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==
   dependencies:
-    get-intrinsic "^1.1.0"
+    get-intrinsic "^1.1.3"
     has "^1.0.3"
     side-channel "^1.0.4"
 
@@ -3967,9 +3963,9 @@ jake@^10.8.5:
     minimatch "^3.0.4"
 
 js-sdsl@^4.1.4:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
-  integrity sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
+  integrity sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -4458,17 +4454,17 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.1:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.4.tgz#ca99f95dd77c43c7a76bf51e6d200025eee0ffae"
-  integrity sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==
-  dependencies:
-    yallist "^4.0.0"
-
-minipass@^3.1.6:
+minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.0.tgz#7cebb0f9fa7d56f0c5b17853cbe28838a8dbbd3b"
+  integrity sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==
   dependencies:
     yallist "^4.0.0"
 
@@ -4611,9 +4607,9 @@ next-tick@^1.1.0:
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 nise@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.2.tgz#a7b8909c216b3491fd4fc0b124efb69f3939b449"
-  integrity sha512-+gQjFi8v+tkfCuSCxfURHLhRhniE/+IaYbIphxAN2JRR9SHKhY8hgXpaXiYfHdw+gcGe4buxgbprBQFab9FkhA==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.3.tgz#f46197e5f60ae9a96401b602bd9d8239b1ee8656"
+  integrity sha512-U597iWTTBBYIV72986jyU382/MMZ70ApWcRmkoF1AZ75bpqOtI3Gugv/6+0jLgoDOabmcSwYBkSSAWIp1eA5cg==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
     "@sinonjs/fake-timers" "^7.0.4"
@@ -4803,13 +4799,13 @@ npmlog@^6.0.0, npmlog@^6.0.2:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
-nx@15.2.3, "nx@>=14.8.6 < 16":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/nx/-/nx-15.2.3.tgz#18568506586122342ecbe43165cdd3e1bcab33c0"
-  integrity sha512-TMHh1WaTCjee0pWYjr81ubFhUUWj3PQLGQxebLlbFO3c5Obs+1QNbT9YHDf83LX/k/V+vRya7Z+ixR7m4x4wkg==
+nx@15.3.3, "nx@>=14.8.6 < 16":
+  version "15.3.3"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-15.3.3.tgz#4ad357310112bad1c4fbfded965bbbe00a2a906f"
+  integrity sha512-yR102AlVW5Sb7X1e9cyR+0h44RD6c3eLJbAZ0yVFKPCKw+zQTdGvAqITtB6ZeFnPkg6Qq6f1oWu6G0n6f2cTpw==
   dependencies:
-    "@nrwl/cli" "15.2.3"
-    "@nrwl/tao" "15.2.3"
+    "@nrwl/cli" "15.3.3"
+    "@nrwl/tao" "15.3.3"
     "@parcel/watcher" "2.0.4"
     "@yarnpkg/lockfile" "^1.1.0"
     "@yarnpkg/parsers" "^3.0.0-rc.18"
@@ -5234,9 +5230,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.4.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
 
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"
@@ -5558,9 +5554,9 @@ run-parallel@^1.1.9:
     queue-microtask "^1.2.2"
 
 rxjs@^7.5.5:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
-  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.6.0.tgz#361da5362b6ddaa691a2de0b4f2d32028f1eb5a2"
+  integrity sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -5832,7 +5828,7 @@ statuses@2.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.trimend@^1.0.5:
+string.prototype.trimend@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
   integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
@@ -5841,7 +5837,7 @@ string.prototype.trimend@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimstart@^1.0.5:
+string.prototype.trimstart@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
   integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
@@ -5945,13 +5941,13 @@ tar-stream@~2.2.0:
     readable-stream "^3.1.1"
 
 tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
-  version "6.1.12"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.12.tgz#3b742fb05669b55671fb769ab67a7791ea1a62e6"
-  integrity sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
+  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^3.0.0"
+    minipass "^4.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
@@ -6160,15 +6156,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@^3 || ^4":
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
-
-typescript@^4.2.3:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+"typescript@^3 || ^4", typescript@^4.2.3:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
- Update to latest modelserver-client version
- Update model uri validation mechanism
- Provide wrapper hook to use validated model uri in interceptor handlers
  - Use hook for all default route providers
- Add default route provider for model element requests
- Clean up some duplicated types and extends route-utils with one generic query type and request handler
- Add README section about routing provider mechanism

Part of eclipse-emfcloud/emfcloud#179

Contributed on behalf of STMicroelectronics